### PR TITLE
[Feature] create controller for balance and add routing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,8 @@ APP_KEY=
 APP_DEBUG=true
 APP_URL=http://localhost
 
+USER_ID=100
+
 LOG_CHANNEL=stack
 LOG_DEPRECATIONS_CHANNEL=null
 LOG_LEVEL=debug

--- a/app/Http/Controllers/BalanceController.php
+++ b/app/Http/Controllers/BalanceController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\UsageLog;
+use App\UserConstant;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use JetBrains\PhpStorm\ArrayShape;
+
+class BalanceController extends Controller
+{
+    #[ArrayShape(["balance" => "int"])]
+    public function getBalance(Request $request): array
+    {
+        // テスト時のみHeaderでユーザーを区別するようにする
+        if (DB::getDatabaseName() == "testing") {
+            // テスト時のユーザー指定に使用
+            $userId = intval($request->header("user_id", UserConstant::USER_ID));
+        } else {
+            // 通常の際には固定のユーザーとする
+            $userId = UserConstant::USER_ID;
+        }
+        /** @noinspection PhpUndefinedMethodInspection (`where` should be callable.)*/
+        $balance = UsageLog::where("user_id", $userId)->sum("changed_amount");
+        return array(
+            "balance" => intval($balance),
+        );
+    }
+}

--- a/app/Http/Controllers/BalanceController.php
+++ b/app/Http/Controllers/BalanceController.php
@@ -3,18 +3,18 @@
 namespace App\Http\Controllers;
 
 use App\Models\UsageLog;
-use JetBrains\PhpStorm\ArrayShape;
+use Illuminate\Http\JsonResponse;
 
 class BalanceController extends Controller
 {
-    #[ArrayShape(["balance" => "int"])]
-    public function getBalance(): array
+    public function getBalance(): JsonResponse
     {
         $userId = intval(config("app.user_id"));
-        /** @noinspection PhpUndefinedMethodInspection (`where` should be callable.)*/
+        /** @noinspection PhpUndefinedMethodInspection (`where` should be callable.) */
         $balance = UsageLog::where("user_id", $userId)->sum("changed_amount");
-        return array(
-            "balance" => intval($balance),
-        );
+        return response()
+            ->json(array(
+                "balance" => intval($balance),
+            ));
     }
 }

--- a/app/Http/Controllers/BalanceController.php
+++ b/app/Http/Controllers/BalanceController.php
@@ -3,24 +3,14 @@
 namespace App\Http\Controllers;
 
 use App\Models\UsageLog;
-use App\UserConstant;
-use Illuminate\Http\Request;
-use Illuminate\Support\Facades\DB;
 use JetBrains\PhpStorm\ArrayShape;
 
 class BalanceController extends Controller
 {
     #[ArrayShape(["balance" => "int"])]
-    public function getBalance(Request $request): array
+    public function getBalance(): array
     {
-        // テスト時のみHeaderでユーザーを区別するようにする
-        if (DB::getDatabaseName() == "testing") {
-            // テスト時のユーザー指定に使用
-            $userId = intval($request->header("user_id", UserConstant::USER_ID));
-        } else {
-            // 通常の際には固定のユーザーとする
-            $userId = UserConstant::USER_ID;
-        }
+        $userId = intval(config("app.user_id"));
         /** @noinspection PhpUndefinedMethodInspection (`where` should be callable.)*/
         $balance = UsageLog::where("user_id", $userId)->sum("changed_amount");
         return array(

--- a/app/UserConstant.php
+++ b/app/UserConstant.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace App;
-
-class UserConstant
-{
-    public const USER_ID = 100;
-}

--- a/app/UserConstant.php
+++ b/app/UserConstant.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App;
+
+class UserConstant
+{
+    public const USER_ID = 100;
+}

--- a/config/app.php
+++ b/config/app.php
@@ -212,4 +212,8 @@ return [
         // 'ExampleClass' => App\Example\ExampleClass::class,
     ])->toArray(),
 
+    /*
+     * User ID
+     */
+    "user_id" => env("USER_ID"),
 ];

--- a/database/seeders/UsageLogSeeder.php
+++ b/database/seeders/UsageLogSeeder.php
@@ -12,6 +12,7 @@ class UsageLogSeeder extends Seeder
      */
     public function run(): void
     {
+        // ここのFactoryではUserId=1のデータを作成している
         UsageLog::factory(10)->create();
         $this->addUser2Data();
         $this->addUser3Data();
@@ -62,7 +63,7 @@ class UsageLogSeeder extends Seeder
             array(-600, "たこ焼き", "2023-02-02T12:30:00"),
             array(-1000, "ラーメン", "2023-02-02T17:30:00"),
         );
-        // 合計は1700円
+        // 金額欄の合計は1700円
         $this->addData($data, 100);
     }
 

--- a/database/seeders/UsageLogSeeder.php
+++ b/database/seeders/UsageLogSeeder.php
@@ -14,6 +14,7 @@ class UsageLogSeeder extends Seeder
     {
         UsageLog::factory(10)->create();
         $this->addUser2Data();
+        $this->addUser3Data();
         $this->addUser100Data();
     }
 
@@ -33,6 +34,19 @@ class UsageLogSeeder extends Seeder
         );
         // 合計は2200円
         $this->addData($data, 2);
+    }
+
+    function addUser3Data(): void
+    {
+        // ダミーデータの配列
+        // 左から金額、使用目的、日時
+        $data = array(
+            array(2000, "チャージ", "2023-02-04T00:00:00"),
+            array(-1500, "ラーメン", "2023-02-04T17:00:00"),
+            array(-1000, "ラーメン", "2023-02-05T18:00:00"),
+        );
+        // 合計は-500円
+        $this->addData($data, 3);
     }
 
     function addUser100Data(): void

--- a/database/seeders/UsageLogSeeder.php
+++ b/database/seeders/UsageLogSeeder.php
@@ -13,10 +13,29 @@ class UsageLogSeeder extends Seeder
     public function run(): void
     {
         UsageLog::factory(10)->create();
-        $this->addCase2();
+        $this->addUser2Data();
+        $this->addUser100Data();
     }
 
-    function addCase2(): void
+    function addUser2Data(): void
+    {
+        // ダミーデータの配列
+        // 左から金額、使用目的、日時
+        $data = array(
+            array(2000, "チャージ", "2023-02-04T00:00:00"),
+            array(-100, "チョコレート", "2023-02-05T07:00:00"),
+            array(-800, "ラーメン", "2023-02-05T012:00:00"),
+            array(3000, "チャージ", "2023-02-05T012:00:00"),
+            array(-600, "たこ焼き", "2023-02-05T018:00:00"),
+            array(-200, "チョコレート", "2023-02-08T07:30:00"),
+            array(-600, "たこ焼き", "2023-02-09T12:30:00"),
+            array(-500, "たこ焼き", "2023-02-10T17:30:00"),
+        );
+        // 合計は2200円
+        $this->addData($data, 2);
+    }
+
+    function addUser100Data(): void
     {
         // ダミーデータの配列
         // 左から金額、使用目的、日時
@@ -29,9 +48,15 @@ class UsageLogSeeder extends Seeder
             array(-600, "たこ焼き", "2023-02-02T12:30:00"),
             array(-1000, "ラーメン", "2023-02-02T17:30:00"),
         );
-        foreach ($data as $datum) {
+        // 合計は1700円
+        $this->addData($data, 100);
+    }
+
+    private function addData(array $data_array, int $userId): void
+    {
+        foreach ($data_array as $datum) {
             UsageLog::factory()->create([
-                "user_id" => 2,
+                "user_id" => $userId,
                 "changed_amount" => $datum[0],
                 "description" => $datum[1],
                 "used_at" => $datum[2],

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\BalanceController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -17,3 +18,5 @@ use Illuminate\Support\Facades\Route;
 Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
+
+Route::get("balance", [BalanceController::class, "getBalance"]);

--- a/tests/Feature/BalanceControllerTest.php
+++ b/tests/Feature/BalanceControllerTest.php
@@ -11,11 +11,20 @@ class BalanceControllerTest extends TestCase
 {
     use RefreshDatabase;
 
+    /**
+     * DBの名前でテスト時かどうか判断しているのでその前提についてテストする。
+     * @return void
+     */
     public function test_assumption_db_name(): void
     {
         $this->assertEquals("testing", DB::getDatabaseName());
     }
 
+    /**
+     * Seederで流し込まれているユーザーの残高を取得する。
+     * UserIdの指定なし(UserId=100)での実行。
+     * @return void
+     */
     public function test_user_default_balance(): void
     {
         $this->seed(UsageLogSeeder::class);
@@ -25,6 +34,12 @@ class BalanceControllerTest extends TestCase
             ->assertJson(["balance" => 1700]);
     }
 
+    /**
+     * Seederで流し込まれているユーザーの残高を取得する。
+     * UserId=2での実行。
+     * 別ユーザーの結果が計算に紛れていないかの確認。
+     * @return void
+     */
     public function test_user_2_balance(): void
     {
         $this->seed(UsageLogSeeder::class);
@@ -34,6 +49,12 @@ class BalanceControllerTest extends TestCase
             ->assertJson(["balance" => 2200]);
     }
 
+    /**
+     * Seederで流し込まれているユーザーの残高を取得する。
+     * UserId=3での実行。
+     * 最終的な残高がマイナスになるケースの確認。
+     * @return void
+     */
     public function test_user_3_balance(): void
     {
         $this->seed(UsageLogSeeder::class);
@@ -43,6 +64,11 @@ class BalanceControllerTest extends TestCase
             ->assertJson(["balance" => -500]);
     }
 
+    /**
+     * 存在しないユーザーの残高を取得する。
+     * 存在していない場合は残高0になっていることを確認する。
+     * @return void
+     */
     public function test_user_no_existence_balance(): void
     {
         $this->seed(UsageLogSeeder::class);

--- a/tests/Feature/BalanceControllerTest.php
+++ b/tests/Feature/BalanceControllerTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Feature;
+
+use Database\Seeders\UsageLogSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class BalanceControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_assumption_db_name(): void
+    {
+        $this->assertEquals("testing", DB::getDatabaseName());
+    }
+
+    public function test_user_default_balance(): void
+    {
+        $this->seed(UsageLogSeeder::class);
+        $response = $this->get("/api/balance");
+        $response
+            ->assertStatus(200)
+            ->assertJson(["balance" => 1700]);
+    }
+
+    public function test_user_2_balance(): void
+    {
+        $this->seed(UsageLogSeeder::class);
+        $response = $this->withHeaders(["user_id" => 2])->get("/api/balance");
+        $response
+            ->assertStatus(200)
+            ->assertJson(["balance" => 2200]);
+    }
+
+    public function test_user_no_existence_balance(): void
+    {
+        $this->seed(UsageLogSeeder::class);
+        $response = $this->withHeaders(["user_id" => -1])->get("/api/balance");
+        $response
+            ->assertStatus(200)
+            ->assertJson(["balance" => 0]);
+    }
+}

--- a/tests/Feature/BalanceControllerTest.php
+++ b/tests/Feature/BalanceControllerTest.php
@@ -4,21 +4,14 @@ namespace Tests\Feature;
 
 use Database\Seeders\UsageLogSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Config;
 use Tests\TestCase;
+
+const USER_ID_KEY = "app.user_id";
 
 class BalanceControllerTest extends TestCase
 {
     use RefreshDatabase;
-
-    /**
-     * DBの名前でテスト時かどうか判断しているのでその前提についてテストする。
-     * @return void
-     */
-    public function test_assumption_db_name(): void
-    {
-        $this->assertEquals("testing", DB::getDatabaseName());
-    }
 
     /**
      * Seederで流し込まれているユーザーの残高を取得する。
@@ -42,8 +35,9 @@ class BalanceControllerTest extends TestCase
      */
     public function test_user_2_balance(): void
     {
+        Config::set(USER_ID_KEY, 2);
         $this->seed(UsageLogSeeder::class);
-        $response = $this->withHeaders(["user_id" => 2])->get("/api/balance");
+        $response = $this->get("/api/balance");
         $response
             ->assertStatus(200)
             ->assertJson(["balance" => 2200]);
@@ -57,8 +51,9 @@ class BalanceControllerTest extends TestCase
      */
     public function test_user_3_balance(): void
     {
+        Config::set(USER_ID_KEY, 3);
         $this->seed(UsageLogSeeder::class);
-        $response = $this->withHeaders(["user_id" => 3])->get("/api/balance");
+        $response = $this->get("/api/balance");
         $response
             ->assertStatus(200)
             ->assertJson(["balance" => -500]);
@@ -71,8 +66,9 @@ class BalanceControllerTest extends TestCase
      */
     public function test_user_no_existence_balance(): void
     {
+        Config::set(USER_ID_KEY, -1);
         $this->seed(UsageLogSeeder::class);
-        $response = $this->withHeaders(["user_id" => -1])->get("/api/balance");
+        $response = $this->get("/api/balance");
         $response
             ->assertStatus(200)
             ->assertJson(["balance" => 0]);

--- a/tests/Feature/BalanceControllerTest.php
+++ b/tests/Feature/BalanceControllerTest.php
@@ -34,6 +34,15 @@ class BalanceControllerTest extends TestCase
             ->assertJson(["balance" => 2200]);
     }
 
+    public function test_user_3_balance(): void
+    {
+        $this->seed(UsageLogSeeder::class);
+        $response = $this->withHeaders(["user_id" => 3])->get("/api/balance");
+        $response
+            ->assertStatus(200)
+            ->assertJson(["balance" => -500]);
+    }
+
     public function test_user_no_existence_balance(): void
     {
         $this->seed(UsageLogSeeder::class);

--- a/tests/Feature/BalanceControllerTest.php
+++ b/tests/Feature/BalanceControllerTest.php
@@ -13,6 +13,12 @@ class BalanceControllerTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(UsageLogSeeder::class);
+    }
+
     /**
      * Seederで流し込まれているユーザーの残高を取得する。
      * UserIdの指定なし(UserId=100)での実行。
@@ -20,7 +26,6 @@ class BalanceControllerTest extends TestCase
      */
     public function test_user_default_balance(): void
     {
-        $this->seed(UsageLogSeeder::class);
         $response = $this->get("/api/balance");
         $response
             ->assertStatus(200)
@@ -36,7 +41,6 @@ class BalanceControllerTest extends TestCase
     public function test_user_2_balance(): void
     {
         Config::set(USER_ID_KEY, 2);
-        $this->seed(UsageLogSeeder::class);
         $response = $this->get("/api/balance");
         $response
             ->assertStatus(200)
@@ -52,7 +56,6 @@ class BalanceControllerTest extends TestCase
     public function test_user_3_balance(): void
     {
         Config::set(USER_ID_KEY, 3);
-        $this->seed(UsageLogSeeder::class);
         $response = $this->get("/api/balance");
         $response
             ->assertStatus(200)
@@ -67,7 +70,6 @@ class BalanceControllerTest extends TestCase
     public function test_user_no_existence_balance(): void
     {
         Config::set(USER_ID_KEY, -1);
-        $this->seed(UsageLogSeeder::class);
         $response = $this->get("/api/balance");
         $response
             ->assertStatus(200)


### PR DESCRIPTION
`/api/balance`に対応するrouteとcontrollerの追加。

ControllerではUsageLogを取得して`changed_amount`を合計し、現在の残高を計算しています。
通常時にはユーザーを固定しています(`user_id=100`)
この時テスト時(DBの名前が"testing"になっている)はheaderからも`user_id`を取得できるようにしています。
ここもっとスマートなやり方がありそうです。

またテストを追加し、テスト用のデータを入れるためにseederを拡張しました。