### PR TITLE
[Feature] create controller charge

### DIFF
--- a/app/ConstMessages.php
+++ b/app/ConstMessages.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App;
+
+class ConstMessages
+{
+    const CHARGE_DESCRIPTION = "チャージ";
+    const CHARGE_SUGGESTION_MESSAGE = "チャージしてください";
+}

--- a/app/Http/Controllers/BalanceController.php
+++ b/app/Http/Controllers/BalanceController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\UserConstant;
 use App\Models\UsageLog;
 use Illuminate\Http\JsonResponse;
 
@@ -9,7 +10,7 @@ class BalanceController extends Controller
 {
     public function getBalance(): JsonResponse
     {
-        $userId = intval(config("app.user_id"));
+        $userId = intval(config(UserConstant::USER_ID_KEY));
         /** @noinspection PhpUndefinedMethodInspection (`where` should be callable.) */
         $balance = UsageLog::where("user_id", $userId)->sum("changed_amount");
         return response()

--- a/app/Http/Controllers/ChargeController.php
+++ b/app/Http/Controllers/ChargeController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\UserConstant;
 use App\Models\UsageLog;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -23,7 +24,7 @@ class ChargeController extends Controller
                 ), Response::HTTP_BAD_REQUEST);
         }
 
-        $userId = intval(config("app.user_id", 100));
+        $userId = intval(config(UserConstant::USER_ID_KEY));
         // 新しいUsageLogの作成
         $chargeValue = intval($request->get("amount"));
         $usage = new UsageLog([

--- a/app/Http/Controllers/ChargeController.php
+++ b/app/Http/Controllers/ChargeController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\UsageLog;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Symfony\Component\HttpFoundation\Response as ResponseCodes;
+
+class ChargeController extends Controller
+{
+    private array $validationRules = [
+        "amount" => ["required", "integer", "numeric", "min:1"]
+    ];
+
+    public function charge(Request $request): Response
+    {
+        $validator = $this->getValidationFactory()->make($request->all(), $this->validationRules);
+        if($validator->fails()){
+            return response("Invalid request", ResponseCodes::HTTP_BAD_REQUEST);
+        }
+
+        $userId = intval(config("app.user_id", 100));
+        // 新しいUsageLogの作成
+        $chargeValue = intval($request->get("amount"));
+        $usage = new UsageLog([
+            "user_id"=>$userId,
+            "used_at"=>now(),
+            "changed_amount"=>$chargeValue,
+            "description"=>"チャージ"
+        ]);
+        // UsageLogをDBに保存
+        $usage->save();
+
+        // 返却値用の残高取得
+        /** @noinspection PhpUndefinedMethodInspection (`where` should be callable.)*/
+        $balance = UsageLog::where("user_id", $userId)->sum("changed_amount");
+        return response(array(
+            "balance"=>$balance
+        ));
+    }
+}

--- a/app/Http/Controllers/ChargeController.php
+++ b/app/Http/Controllers/ChargeController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\ConstMessages;
 use App\Http\UserConstant;
 use App\Models\UsageLog;
 use Illuminate\Http\JsonResponse;
@@ -29,7 +30,7 @@ class ChargeController extends Controller
             "user_id" => $userId,
             "used_at" => now(),
             "changed_amount" => $chargeValue,
-            "description" => "チャージ"
+            "description" => ConstMessages::CHARGE_DESCRIPTION,
         ]);
         // UsageLogをDBに保存
         $usage->save();
@@ -42,7 +43,7 @@ class ChargeController extends Controller
         );
         // チャージ後の残高がマイナスならチャージを促すメッセージを入れる。
         if ($balance <= 0) {
-            $returnValue["message"] = "チャージしてください";
+            $returnValue["message"] = ConstMessages::CHARGE_SUGGESTION_MESSAGE;
         }
         return response()
             ->json($returnValue);

--- a/app/Http/Controllers/ChargeController.php
+++ b/app/Http/Controllers/ChargeController.php
@@ -37,9 +37,14 @@ class ChargeController extends Controller
         // 返却値用の残高取得
         /** @noinspection PhpUndefinedMethodInspection (`where` should be callable.) */
         $balance = UsageLog::where("user_id", $userId)->sum("changed_amount");
+        $returnValue = array(
+            "balance" => $balance,
+        );
+        // チャージ後の残高がマイナスならチャージを促すメッセージを入れる。
+        if ($balance <= 0) {
+            $returnValue["message"] = "チャージしてください";
+        }
         return response()
-            ->json(array(
-                "balance" => $balance,
-            ));
+            ->json($returnValue);
     }
 }

--- a/app/Http/UserConstant.php
+++ b/app/Http/UserConstant.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Http;
+
+class UserConstant
+{
+    const USER_ID_KEY = "app.user_id";
+}

--- a/app/Models/UsageLog.php
+++ b/app/Models/UsageLog.php
@@ -15,4 +15,10 @@ class UsageLog extends Model
         return UsageLogFactory::new();
     }
 
+    protected $fillable = [
+        "user_id",
+        "used_at",
+        "changed_amount",
+        "description",
+    ];
 }

--- a/database/factories/UsageLogFactory.php
+++ b/database/factories/UsageLogFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\ConstMessages;
 use App\Models\UsageLog;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
@@ -18,7 +19,7 @@ class UsageLogFactory extends Factory
     public function definition(): array
     {
         $changeAmount = fake()->numberBetween(-10000, 10000);
-        $description = $changeAmount > 0 ? "チャージ" : fake()->randomElement(["ラーメン", "たこ焼き", "アイス"]);
+        $description = $changeAmount > 0 ? ConstMessages::CHARGE_DESCRIPTION : fake()->randomElement(["ラーメン", "たこ焼き", "アイス"]);
         return [
             "user_id" => 1,
             "used_at" => now(),

--- a/database/seeders/UsageLogSeeder.php
+++ b/database/seeders/UsageLogSeeder.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeders;
 
+use App\ConstMessages;
 use App\Models\UsageLog;
 use Illuminate\Database\Seeder;
 
@@ -24,10 +25,10 @@ class UsageLogSeeder extends Seeder
         // ダミーデータの配列
         // 左から金額、使用目的、日時
         $data = array(
-            array(2000, "チャージ", "2023-02-04T00:00:00"),
+            array(2000, ConstMessages::CHARGE_DESCRIPTION, "2023-02-04T00:00:00"),
             array(-100, "チョコレート", "2023-02-05T07:00:00"),
             array(-800, "ラーメン", "2023-02-05T012:00:00"),
-            array(3000, "チャージ", "2023-02-05T012:00:00"),
+            array(3000, ConstMessages::CHARGE_DESCRIPTION, "2023-02-05T012:00:00"),
             array(-600, "たこ焼き", "2023-02-05T018:00:00"),
             array(-200, "チョコレート", "2023-02-08T07:30:00"),
             array(-600, "たこ焼き", "2023-02-09T12:30:00"),
@@ -42,7 +43,7 @@ class UsageLogSeeder extends Seeder
         // ダミーデータの配列
         // 左から金額、使用目的、日時
         $data = array(
-            array(2000, "チャージ", "2023-02-04T00:00:00"),
+            array(2000, ConstMessages::CHARGE_DESCRIPTION, "2023-02-04T00:00:00"),
             array(-1500, "ラーメン", "2023-02-04T17:00:00"),
             array(-1000, "ラーメン", "2023-02-05T18:00:00"),
         );
@@ -55,7 +56,7 @@ class UsageLogSeeder extends Seeder
         // ダミーデータの配列
         // 左から金額、使用目的、日時
         $data = array(
-            array(5000, "チャージ", "2023-02-01T00:00:00"),
+            array(5000, ConstMessages::CHARGE_DESCRIPTION, "2023-02-01T00:00:00"),
             array(-100, "アイス", "2023-02-01T07:00:00"),
             array(-800, "ラーメン", "2023-02-01T012:00:00"),
             array(-600, "たこ焼き", "2023-02-01T018:00:00"),

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\ChargeController;
 use App\Http\Controllers\BalanceController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
@@ -19,4 +20,5 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
 
+Route::post("charge", [ChargeController::class, "charge"]);
 Route::get("balance", [BalanceController::class, "getBalance"]);

--- a/tests/Feature/BalanceControllerTest.php
+++ b/tests/Feature/BalanceControllerTest.php
@@ -2,12 +2,11 @@
 
 namespace Tests\Feature;
 
+use App\Http\UserConstant;
 use Database\Seeders\UsageLogSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Config;
 use Tests\TestCase;
-
-const USER_ID_KEY = "app.user_id";
 
 class BalanceControllerTest extends TestCase
 {
@@ -40,7 +39,7 @@ class BalanceControllerTest extends TestCase
      */
     public function test_user_2_balance(): void
     {
-        Config::set(USER_ID_KEY, 2);
+        Config::set(UserConstant::USER_ID_KEY, 2);
         $response = $this->get("/api/balance");
         $response
             ->assertStatus(200)
@@ -55,7 +54,7 @@ class BalanceControllerTest extends TestCase
      */
     public function test_user_3_balance(): void
     {
-        Config::set(USER_ID_KEY, 3);
+        Config::set(UserConstant::USER_ID_KEY, 3);
         $response = $this->get("/api/balance");
         $response
             ->assertStatus(200)
@@ -69,7 +68,7 @@ class BalanceControllerTest extends TestCase
      */
     public function test_user_no_existence_balance(): void
     {
-        Config::set(USER_ID_KEY, -1);
+        Config::set(UserConstant::USER_ID_KEY, -1);
         $response = $this->get("/api/balance");
         $response
             ->assertStatus(200)

--- a/tests/Feature/ChargeTest.php
+++ b/tests/Feature/ChargeTest.php
@@ -124,6 +124,58 @@ class ChargeTest extends TestCase
     }
 
     /**
+     * UserId=3でチャージし、残高がプラスならチャージのメッセージが入っていないことを確認
+     */
+    public function test_charge_user_3_plus(): void
+    {
+        // User3は-500円の残高
+        $this->seed(UsageLogSeeder::class);
+        Config::set(UserConstant::USER_ID_KEY, 3);
+
+        $response = $this->postJson("/api/charge", [
+            "amount" => 1000,
+        ]);
+        $response
+            ->assertStatus(200)
+            ->assertJson(["balance" => 500])
+            ->assertJsonMissingExact(["message" => "チャージしてください"]);
+    }
+
+    /**
+     * UserId=3で残高が0になる場合チャージのメッセージが含まれる。
+     */
+    public function test_charge_user_3_zero(): void
+    {
+        // User3は-500円の残高
+        $this->seed(UsageLogSeeder::class);
+        Config::set(UserConstant::USER_ID_KEY, 3);
+
+        $response = $this->postJson("/api/charge", [
+            "amount" => 500,
+        ]);
+        $response
+            ->assertStatus(200)
+            ->assertJson(["balance" => 0, "message" => "チャージしてください"]);
+    }
+
+    /**
+     * UserId=3で残高がマイナスになる場合チャージのメッセージが含まれる。
+     */
+    public function test_charge_user_3_minus(): void
+    {
+        // User3は-500円の残高
+        $this->seed(UsageLogSeeder::class);
+        Config::set(UserConstant::USER_ID_KEY, 3);
+
+        $response = $this->postJson("/api/charge", [
+            "amount" => 499,
+        ]);
+        $response
+            ->assertStatus(200)
+            ->assertJson(["balance" => -1, "message" => "チャージしてください"]);
+    }
+
+    /**
      * amountが文字列でも有効な数字であれば受け付けることを確認する。
      * @return void
      */

--- a/tests/Feature/ChargeTest.php
+++ b/tests/Feature/ChargeTest.php
@@ -2,13 +2,12 @@
 
 namespace Tests\Feature;
 
+use App\Http\UserConstant;
 use App\Models\UsageLog;
 use Database\Seeders\UsageLogSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Config;
 use Tests\TestCase;
-
-const USER_ID_KEY = "app.user_id";
 
 class ChargeTest extends TestCase
 {
@@ -68,7 +67,7 @@ class ChargeTest extends TestCase
     {
         $this->seed(UsageLogSeeder::class);
         // seederでは201番のユーザーは追加していないのでこの番号を使用してテストする
-        Config::set(USER_ID_KEY, 201);
+        Config::set(UserConstant::USER_ID_KEY, 201);
         $response = $this->post("/api/charge", [
             "amount" => 500
         ]);
@@ -107,7 +106,7 @@ class ChargeTest extends TestCase
         // DBの内容に追記した際にも正常動作することを確認
         // User 2は元々2200円残高がある
         $this->seed(UsageLogSeeder::class);
-        Config::set(USER_ID_KEY, 2);
+        Config::set(UserConstant::USER_ID_KEY, 2);
         $response = $this->post("/api/charge", [
             "amount" => 1500
         ]);

--- a/tests/Feature/ChargeTest.php
+++ b/tests/Feature/ChargeTest.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\UsageLog;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Tests\TestCase;
+
+const USER_ID_KEY = "app.user_id";
+
+class ChargeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * UserIdの指定なしでチャージを1回行う。
+     * Seederの実行はないので初期値は0。
+     * また、レコード内のdescriptionが"チャージ"となっていることを確認する。
+     * @return void
+     */
+    public function test_charge_user_default_once(): void
+    {
+        $response = $this->post("/api/charge", [
+            "amount" => 1
+        ]);
+        $response
+            ->assertStatus(200)
+            ->assertJson(["balance" => 1]);
+
+        // DB内でdescriptionがチャージになっているか確認
+        /** @noinspection PhpUndefinedMethodInspection */
+        $log = UsageLog::firstWhere("user_id", 100);
+        $this->assertEquals("チャージ", $log->description);
+
+    }
+
+    /**
+     * UserIdの指定なしでチャージを2回行う。
+     * Seederの実行はないので初期値は0。
+     * @return void
+     */
+    public function test_charge_user_default_twice(): void
+    {
+        $response = $this->post("/api/charge", [
+            "amount" => 500
+        ]);
+        $response
+            ->assertStatus(200)
+            ->assertJson(["balance" => 500]);
+
+        // Second trial, balance must be 1000.
+        $response = $this->post("/api/charge", [
+            "amount" => 500
+        ]);
+        $response
+            ->assertStatus(200)
+            ->assertJson(["balance" => 1000]);
+    }
+
+    /**
+     * UserId=201でチャージを2回行う。
+     * Seederには201番のユーザーは存在しないので初期値は0。
+     * @return void
+     */
+    public function test_charge_user_201(): void
+    {
+        $this->seed();
+        // seederでは201番のユーザーは追加していないのでこの番号を使用してテストする
+        Config::set(USER_ID_KEY, 201);
+        $response = $this->post("/api/charge", [
+            "amount" => 500
+        ]);
+        $response
+            ->assertStatus(200)
+            ->assertJson(["balance" => 500]);
+
+        // DB内でdescriptionがチャージになっているか確認
+        /** @noinspection PhpUndefinedMethodInspection */
+        $log = UsageLog::firstWhere("user_id", 201);
+        $this->assertEquals("チャージ", $log->description);
+
+        // 2nd charge
+        $response = $this->post("/api/charge", [
+            "amount" => 1500
+        ]);
+        $response
+            ->assertStatus(200)
+            ->assertJson(["balance" => 2000]);
+
+        // 別ユーザーのDBに変更がないか確認
+        /** @noinspection PhpUndefinedMethodInspection */
+        $this->assertEquals(0, UsageLog::where("user_id", 100)->sum("changed_amount"));
+        /** @noinspection PhpUndefinedMethodInspection */
+        $this->assertEquals(1700, UsageLog::where("user_id", 2)->sum("changed_amount"));
+    }
+
+    /**
+     * UserId=2でチャージする。
+     * Seederでデータが流し込まれているので初期値は1700円。
+     * 元々の残高に追加されていることを確認する。
+     * @return void
+     */
+    public function test_charge_user_2(): void
+    {
+        // DBの内容に追記した際にも正常動作することを確認
+        // User 2は元々1700円残高がある
+        $this->seed();
+        Config::set(USER_ID_KEY, 2);
+        $response = $this->post("/api/charge", [
+            "amount" => 1500
+        ]);
+        $response
+            ->assertStatus(200)
+            ->assertJson(["balance" => 3200]);
+    }
+
+    /**
+     * amountが文字列でも有効な数字であれば受け付けることを確認する。
+     * @return void
+     */
+    public function test_amount_string_number(): void
+    {
+        $response = $this->post("/api/charge", [
+            "amount" => "300"
+        ]);
+        $response
+            ->assertStatus(200)
+            ->assertJson(["balance" => 300]);
+    }
+
+    /**
+     * Bodyがない場合にエラー
+     * @return void
+     */
+    public function test_no_body(): void
+    {
+        $response = $this->post("/api/charge");
+        $response->assertStatus(400);
+    }
+
+    /**
+     * amount=0の場合にエラー
+     * @return void
+     */
+    public function test_amount_0(): void
+    {
+        $response = $this->post("/api/charge", [
+            "amount" => 0
+        ]);
+        $response->assertStatus(400);
+    }
+
+    /**
+     * amount < 0の場合にエラー
+     * 代表値として-1を使用
+     * @return void
+     */
+    public function test_amount_minus(): void
+    {
+        $response = $this->post("/api/charge", [
+            "amount" => -1
+        ]);
+        $response->assertStatus(400);
+    }
+
+    /**
+     * amountが無効な文字列の場合にエラー
+     * @return void
+     */
+    public function test_amount_string(): void
+    {
+        $response = $this->post("/api/charge", [
+            "amount" => "Hey"
+        ]);
+        $response->assertStatus(400);
+    }
+
+}

--- a/tests/Feature/ChargeTest.php
+++ b/tests/Feature/ChargeTest.php
@@ -7,6 +7,7 @@ use App\Models\UsageLog;
 use Database\Seeders\UsageLogSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Config;
+use Symfony\Component\HttpFoundation\Response;
 use Tests\TestCase;
 
 class ChargeTest extends TestCase
@@ -29,7 +30,7 @@ class ChargeTest extends TestCase
     {
         $response = $this->post("/api/charge", [
             "amount" => 1
-        ]);
+        ], ["Accept" => "application/json"]);
         $response
             ->assertStatus(200)
             ->assertJson(["balance" => 1]);
@@ -50,7 +51,7 @@ class ChargeTest extends TestCase
     {
         $response = $this->post("/api/charge", [
             "amount" => 500
-        ]);
+        ], ["Accept" => "application/json"]);
         $response
             ->assertStatus(200)
             ->assertJson(["balance" => 500]);
@@ -58,7 +59,7 @@ class ChargeTest extends TestCase
         // 2回目。1000円になるはず。
         $response = $this->post("/api/charge", [
             "amount" => 500
-        ]);
+        ], ["Accept" => "application/json"]);
         $response
             ->assertStatus(200)
             ->assertJson(["balance" => 1000]);
@@ -78,7 +79,7 @@ class ChargeTest extends TestCase
         Config::set(UserConstant::USER_ID_KEY, 201);
         $response = $this->post("/api/charge", [
             "amount" => 500
-        ]);
+        ], ["Accept" => "application/json"]);
         $response
             ->assertStatus(200)
             ->assertJson(["balance" => 500]);
@@ -91,7 +92,7 @@ class ChargeTest extends TestCase
         // 2nd charge
         $response = $this->post("/api/charge", [
             "amount" => 1500
-        ]);
+        ], ["Accept" => "application/json"]);
         $response
             ->assertStatus(200)
             ->assertJson(["balance" => 2000]);
@@ -116,7 +117,7 @@ class ChargeTest extends TestCase
         Config::set(UserConstant::USER_ID_KEY, 2);
         $response = $this->post("/api/charge", [
             "amount" => 1500
-        ]);
+        ], ["Accept" => "application/json"]);
         $response
             ->assertStatus(200)
             ->assertJson(["balance" => 3700]);
@@ -130,7 +131,7 @@ class ChargeTest extends TestCase
     {
         $response = $this->post("/api/charge", [
             "amount" => "300"
-        ]);
+        ], ["Accept" => "application/json"]);
         $response
             ->assertStatus(200)
             ->assertJson(["balance" => 300]);
@@ -145,8 +146,8 @@ class ChargeTest extends TestCase
     {
         // 実行前の残高。0円のはず。
         $preBalance = $this->getBalanceForUser(100);
-        $response = $this->post("/api/charge");
-        $response->assertStatus(400);
+        $response = $this->post("/api/charge", [], ["Accept" => "application/json"]);
+        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
         $this->assertEquals($preBalance, $this->getBalanceForUser(100));
     }
 
@@ -158,8 +159,8 @@ class ChargeTest extends TestCase
     {
         $response = $this->post("/api/charge", [
             "amount" => 0
-        ]);
-        $response->assertStatus(400);
+        ], ["Accept" => "application/json"]);
+        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
     }
 
     /**
@@ -171,8 +172,8 @@ class ChargeTest extends TestCase
     {
         $response = $this->post("/api/charge", [
             "amount" => -1
-        ]);
-        $response->assertStatus(400);
+        ], ["Accept" => "application/json"]);
+        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
     }
 
     /**
@@ -183,8 +184,8 @@ class ChargeTest extends TestCase
     {
         $response = $this->post("/api/charge", [
             "amount" => "Hey"
-        ]);
-        $response->assertStatus(400);
+        ], ["Accept" => "application/json"]);
+        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
     }
 
 }

--- a/tests/Feature/ChargeTest.php
+++ b/tests/Feature/ChargeTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Models\UsageLog;
+use Database\Seeders\UsageLogSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Config;
 use Tests\TestCase;
@@ -65,7 +66,7 @@ class ChargeTest extends TestCase
      */
     public function test_charge_user_201(): void
     {
-        $this->seed();
+        $this->seed(UsageLogSeeder::class);
         // seederでは201番のユーザーは追加していないのでこの番号を使用してテストする
         Config::set(USER_ID_KEY, 201);
         $response = $this->post("/api/charge", [
@@ -90,9 +91,9 @@ class ChargeTest extends TestCase
 
         // 別ユーザーのDBに変更がないか確認
         /** @noinspection PhpUndefinedMethodInspection */
-        $this->assertEquals(0, UsageLog::where("user_id", 100)->sum("changed_amount"));
+        $this->assertEquals(1700, UsageLog::where("user_id", 100)->sum("changed_amount"));
         /** @noinspection PhpUndefinedMethodInspection */
-        $this->assertEquals(1700, UsageLog::where("user_id", 2)->sum("changed_amount"));
+        $this->assertEquals(2200, UsageLog::where("user_id", 2)->sum("changed_amount"));
     }
 
     /**
@@ -104,15 +105,15 @@ class ChargeTest extends TestCase
     public function test_charge_user_2(): void
     {
         // DBの内容に追記した際にも正常動作することを確認
-        // User 2は元々1700円残高がある
-        $this->seed();
+        // User 2は元々2200円残高がある
+        $this->seed(UsageLogSeeder::class);
         Config::set(USER_ID_KEY, 2);
         $response = $this->post("/api/charge", [
             "amount" => 1500
         ]);
         $response
             ->assertStatus(200)
-            ->assertJson(["balance" => 3200]);
+            ->assertJson(["balance" => 3700]);
     }
 
     /**

--- a/tests/Feature/ChargeTest.php
+++ b/tests/Feature/ChargeTest.php
@@ -28,9 +28,9 @@ class ChargeTest extends TestCase
      */
     public function test_charge_user_default_once(): void
     {
-        $response = $this->post("/api/charge", [
+        $response = $this->postJson("/api/charge", [
             "amount" => 1
-        ], ["Accept" => "application/json"]);
+        ]);
         $response
             ->assertStatus(200)
             ->assertJson(["balance" => 1]);
@@ -49,17 +49,17 @@ class ChargeTest extends TestCase
      */
     public function test_charge_user_default_twice(): void
     {
-        $response = $this->post("/api/charge", [
+        $response = $this->postJson("/api/charge", [
             "amount" => 500
-        ], ["Accept" => "application/json"]);
+        ]);
         $response
             ->assertStatus(200)
             ->assertJson(["balance" => 500]);
 
         // 2回目。1000円になるはず。
-        $response = $this->post("/api/charge", [
+        $response = $this->postJson("/api/charge", [
             "amount" => 500
-        ], ["Accept" => "application/json"]);
+        ]);
         $response
             ->assertStatus(200)
             ->assertJson(["balance" => 1000]);
@@ -77,9 +77,9 @@ class ChargeTest extends TestCase
         $this->seed(UsageLogSeeder::class);
         // seederでは201番のユーザーは追加していないのでこの番号を使用してテストする
         Config::set(UserConstant::USER_ID_KEY, 201);
-        $response = $this->post("/api/charge", [
+        $response = $this->postJson("/api/charge", [
             "amount" => 500
-        ], ["Accept" => "application/json"]);
+        ]);
         $response
             ->assertStatus(200)
             ->assertJson(["balance" => 500]);
@@ -90,9 +90,9 @@ class ChargeTest extends TestCase
         $this->assertEquals("チャージ", $log->description);
 
         // 2nd charge
-        $response = $this->post("/api/charge", [
+        $response = $this->postJson("/api/charge", [
             "amount" => 1500
-        ], ["Accept" => "application/json"]);
+        ]);
         $response
             ->assertStatus(200)
             ->assertJson(["balance" => 2000]);
@@ -115,9 +115,9 @@ class ChargeTest extends TestCase
         // User 2は元々2200円残高がある
         $this->seed(UsageLogSeeder::class);
         Config::set(UserConstant::USER_ID_KEY, 2);
-        $response = $this->post("/api/charge", [
+        $response = $this->postJson("/api/charge", [
             "amount" => 1500
-        ], ["Accept" => "application/json"]);
+        ]);
         $response
             ->assertStatus(200)
             ->assertJson(["balance" => 3700]);
@@ -129,9 +129,9 @@ class ChargeTest extends TestCase
      */
     public function test_amount_string_number(): void
     {
-        $response = $this->post("/api/charge", [
+        $response = $this->postJson("/api/charge", [
             "amount" => "300"
-        ], ["Accept" => "application/json"]);
+        ]);
         $response
             ->assertStatus(200)
             ->assertJson(["balance" => 300]);
@@ -146,7 +146,7 @@ class ChargeTest extends TestCase
     {
         // 実行前の残高。0円のはず。
         $preBalance = $this->getBalanceForUser(100);
-        $response = $this->post("/api/charge", [], ["Accept" => "application/json"]);
+        $response = $this->postJson("/api/charge");
         $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
         $this->assertEquals($preBalance, $this->getBalanceForUser(100));
     }
@@ -157,9 +157,9 @@ class ChargeTest extends TestCase
      */
     public function test_amount_0(): void
     {
-        $response = $this->post("/api/charge", [
+        $response = $this->postJson("/api/charge", [
             "amount" => 0
-        ], ["Accept" => "application/json"]);
+        ]);
         $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
     }
 
@@ -170,9 +170,9 @@ class ChargeTest extends TestCase
      */
     public function test_amount_minus(): void
     {
-        $response = $this->post("/api/charge", [
+        $response = $this->postJson("/api/charge", [
             "amount" => -1
-        ], ["Accept" => "application/json"]);
+        ]);
         $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
     }
 
@@ -182,9 +182,9 @@ class ChargeTest extends TestCase
      */
     public function test_amount_string(): void
     {
-        $response = $this->post("/api/charge", [
+        $response = $this->postJson("/api/charge", [
             "amount" => "Hey"
-        ], ["Accept" => "application/json"]);
+        ]);
         $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
     }
 

--- a/tests/Feature/ChargeTest.php
+++ b/tests/Feature/ChargeTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\ConstMessages;
 use App\Http\UserConstant;
 use App\Models\UsageLog;
 use Database\Seeders\UsageLogSeeder;
@@ -38,7 +39,7 @@ class ChargeTest extends TestCase
         // DB内でdescriptionがチャージになっているか確認
         /** @noinspection PhpUndefinedMethodInspection */
         $log = UsageLog::firstWhere("user_id", 100);
-        $this->assertEquals("チャージ", $log->description);
+        $this->assertEquals(ConstMessages::CHARGE_DESCRIPTION, $log->description);
 
     }
 
@@ -87,7 +88,7 @@ class ChargeTest extends TestCase
         // DB内でdescriptionがチャージになっているか確認
         /** @noinspection PhpUndefinedMethodInspection */
         $log = UsageLog::firstWhere("user_id", 201);
-        $this->assertEquals("チャージ", $log->description);
+        $this->assertEquals(ConstMessages::CHARGE_DESCRIPTION, $log->description);
 
         // 2nd charge
         $response = $this->postJson("/api/charge", [
@@ -138,7 +139,7 @@ class ChargeTest extends TestCase
         $response
             ->assertStatus(200)
             ->assertJson(["balance" => 500])
-            ->assertJsonMissingExact(["message" => "チャージしてください"]);
+            ->assertJsonMissingExact(["message" => ConstMessages::CHARGE_SUGGESTION_MESSAGE]);
     }
 
     /**
@@ -155,7 +156,7 @@ class ChargeTest extends TestCase
         ]);
         $response
             ->assertStatus(200)
-            ->assertJson(["balance" => 0, "message" => "チャージしてください"]);
+            ->assertJson(["balance" => 0, "message" => ConstMessages::CHARGE_SUGGESTION_MESSAGE]);
     }
 
     /**
@@ -172,7 +173,7 @@ class ChargeTest extends TestCase
         ]);
         $response
             ->assertStatus(200)
-            ->assertJson(["balance" => -1, "message" => "チャージしてください"]);
+            ->assertJson(["balance" => -1, "message" => ConstMessages::CHARGE_SUGGESTION_MESSAGE]);
     }
 
     /**


### PR DESCRIPTION
仕様のページ: https://www.notion.so/yumemi/api-charge-7baaa250e4564bc4bc205bf27f778b86
テストの要件: https://www.notion.so/yumemi/688a657310294a88a029672f83cd61ab?p=0488472ce31849f8b8d1e6abd72cd57e&pm=s

## やったこと

* `/api/charge`のコントローラーとroutingの設定
* テストコードの追加

## やらないこと

* 逆の操作である、`/api/use`はまた後日実装する

## できるようになること（ユーザ目線）

* チャージできるようになる

## できなくなること（ユーザ目線）

* なし

## 動作確認

* テストコードによって動作確認
  * 正常系
  * テストユーザーを指定した正常系
  * 異常系
    * bodyがないケース
    * amountの値が不正なケース
* このPRだけでは外から残高を取得する手段がないのでcurlなどによる実際のリクエストのテストはしていません

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
  * [Q] 異常なケースに対するレスポンスコードは`400`でいいか
    * Or 422?
    * 422で書き直してあります
  * [Q] `config(key)`でキーが存在しない場合にエラーにすることはできるか
