### PR TITLE
Prebuild image to use cache in GitHub Action.

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -22,6 +22,21 @@ jobs:
       run: composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
     - name: Generate key
       run: php artisan key:generate
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+    - name: Get GID
+      run: echo "WWWGROUP=$(id -g)" >> $GITHUB_ENV
+    - name: Prebuild image
+      uses: docker/build-push-action@v4
+      with:
+        # Copied from docker-compose.yml
+        context: ./vendor/laravel/sail/runtimes/8.2
+        load: true
+        tags: sail-8.2/app:latest
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        build-args: |
+          WWWGROUP=${{ env.WWWGROUP }}
     - name: Sail Up
       run: ./vendor/bin/sail up -d
     - name: Check containers

--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -25,7 +25,9 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
     - name: Get GID
-      run: echo "WWWGROUP=$(id -g)" >> $GITHUB_ENV
+      run: |
+        echo "WWWGROUP=$(id -g)" >> $GITHUB_ENV
+        echo "WWWUSER=$(id -u)" >> $GITHUB_ENV
     - name: Prebuild image
       uses: docker/build-push-action@v4
       with:


### PR DESCRIPTION
## やったこと

* `sail up`する前にイメージのビルドを行った
* このビルドにはActionsのキャッシュを使うように設定している
  * これまでは`sail up`の際に毎回ビルドしていたので1回の実行に3, 4分かかっていた

## やらないこと

* composerのキャッシュはしない
  * もともと10秒程度で終わっていたため

## 動作確認

* PR時にActionsを複数回回して実行時間の比較をする
* 4min -> 2.5min

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
* 使用しているbuild用のactionについて
  * https://github.com/docker/build-push-action
* Actionのキャッシュを使う際の設定の例
  * https://docs.docker.com/build/ci/github-actions/cache/
