### PR TITLE
[Feature] Create controller for use

### DIFF
--- a/app/ConstMessages.php
+++ b/app/ConstMessages.php
@@ -6,4 +6,5 @@ class ConstMessages
 {
     const CHARGE_DESCRIPTION = "チャージ";
     const CHARGE_SUGGESTION_MESSAGE = "チャージしてください";
+    const BALANCE_MINUS_MESSAGE = "残高がマイナスです。チャージしてください。";
 }

--- a/app/Http/Controllers/UseController.php
+++ b/app/Http/Controllers/UseController.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\UsageLog;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class UseController extends Controller
+{
+    private array $validationRules = [
+        "amount" => ["required", "integer", "numeric", "min:1"],
+        "description" => ["required", "string"],
+    ];
+
+    public function use(Request $request): JsonResponse
+    {
+        // 入力値のチェック。要件を満たしていない場合は400
+        $validator = $this->getValidationFactory()->make($request->all(), $this->validationRules);
+        if ($validator->fails()) {
+            return response()
+                ->json(array(
+                    "message" => "Invalid request.",
+                ), Response::HTTP_UNPROCESSABLE_ENTITY);
+        }
+        $userId = intval(config("app.user_id"));
+        /** @noinspection PhpUndefinedMethodInspection (`where` should be callable.) */
+        $balance = UsageLog::where("user_id", $userId)->sum("changed_amount");
+        // 残高が0円以下なら使用しない。チャージを促して400を返す。
+        if ($balance <= 0) {
+            return response()
+                ->json(array(
+                    "message" => "残高がマイナスです。チャージしてください。"
+                ), Response::HTTP_BAD_REQUEST);
+        }
+
+        // 使用できる。ログをDBに残す。
+        $chargeValue = intval($request->get("amount"));
+        $usage = new UsageLog([
+            "user_id" => $userId,
+            "used_at" => now(),
+            "changed_amount" => -$chargeValue,
+            "description" => $request->get("description"),
+        ]);
+        // UsageLogをDBに保存
+        $usage->save();
+
+        // 使用後の残高の計算。
+        $newBalance = $balance - $chargeValue;
+        $returnValue = array(
+            "balance" => $newBalance
+        );
+        // 使用後の残高がマイナスならチャージを促すメッセージを入れる。
+        if ($newBalance <= 0) {
+            $returnValue["message"] = "チャージしてください";
+        }
+        return response()
+            ->json($returnValue);
+    }
+}

--- a/app/Http/Controllers/UseController.php
+++ b/app/Http/Controllers/UseController.php
@@ -36,18 +36,18 @@ class UseController extends Controller
         }
 
         // 使用できる。ログをDBに残す。
-        $chargeValue = intval($request->get("amount"));
+        $useValue = intval($request->get("amount"));
         $usage = new UsageLog([
             "user_id" => $userId,
             "used_at" => now(),
-            "changed_amount" => -$chargeValue,
+            "changed_amount" => -$useValue,
             "description" => $request->get("description"),
         ]);
         // UsageLogをDBに保存
         $usage->save();
 
         // 使用後の残高の計算。
-        $newBalance = $balance - $chargeValue;
+        $newBalance = $balance - $useValue;
         $returnValue = array(
             "balance" => $newBalance
         );

--- a/app/Http/Controllers/UseController.php
+++ b/app/Http/Controllers/UseController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\ConstMessages;
 use App\Models\UsageLog;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -30,7 +31,7 @@ class UseController extends Controller
         if ($balance <= 0) {
             return response()
                 ->json(array(
-                    "message" => "残高がマイナスです。チャージしてください。"
+                    "message" => ConstMessages::BALANCE_MINUS_MESSAGE
                 ), Response::HTTP_BAD_REQUEST);
         }
 
@@ -52,7 +53,7 @@ class UseController extends Controller
         );
         // 使用後の残高がマイナスならチャージを促すメッセージを入れる。
         if ($newBalance <= 0) {
-            $returnValue["message"] = "チャージしてください";
+            $returnValue["message"] = ConstMessages::CHARGE_SUGGESTION_MESSAGE;
         }
         return response()
             ->json($returnValue);

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\ChargeController;
 use App\Http\Controllers\BalanceController;
+use App\Http\Controllers\UseController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -22,3 +23,4 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 
 Route::post("charge", [ChargeController::class, "charge"]);
 Route::get("balance", [BalanceController::class, "getBalance"]);
+Route::post("use", [UseController::class, "use"]);

--- a/tests/Feature/UseControllerTest.php
+++ b/tests/Feature/UseControllerTest.php
@@ -149,6 +149,24 @@ class UseControllerTest extends TestCase
     }
 
     /**
+     * 残高0円のUserId=201が使用する。
+     * もともと0円なので400
+     * @return void
+     */
+    public function test_user_201_use(): void
+    {
+        Config::set("app.user_id", 201);
+        $response = $this->postJson("/api/use", array(
+            "amount" => 700,
+            "description" => "test_user_201_use",
+        ));
+        $response
+            ->assertStatus(Response::HTTP_BAD_REQUEST)
+            ->assertJson(array("message" => "残高がマイナスです。チャージしてください。"));
+        $this->assertEquals(0, $this->getBalanceForUser(201));
+    }
+
+    /**
      * dataなし
      */
     public function test_no_data(): void

--- a/tests/Feature/UseControllerTest.php
+++ b/tests/Feature/UseControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\ConstMessages;
 use App\Models\UsageLog;
 use Database\Seeders\UsageLogSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -72,7 +73,7 @@ class UseControllerTest extends TestCase
                 "balance" => 1,
             ))
             ->assertJsonMissingExact(array(
-                "message" => "チャージしてください",
+                "message" => ConstMessages::CHARGE_SUGGESTION_MESSAGE,
             ));
         $this->assertEquals(1, $this->getBalanceForUser(100));
     }
@@ -96,7 +97,7 @@ class UseControllerTest extends TestCase
             ->assertStatus(Response::HTTP_OK)
             ->assertJson(array(
                 "balance" => 0,
-                "message" => "チャージしてください",
+                "message" => ConstMessages::CHARGE_SUGGESTION_MESSAGE,
             ));
         $this->assertEquals(0, $this->getBalanceForUser(100));
     }
@@ -120,7 +121,7 @@ class UseControllerTest extends TestCase
             ->assertStatus(Response::HTTP_OK)
             ->assertJson(array(
                 "balance" => -1,
-                "message" => "チャージしてください",
+                "message" => ConstMessages::CHARGE_SUGGESTION_MESSAGE,
             ));
         $this->assertEquals(-1, $this->getBalanceForUser(100));
     }
@@ -143,7 +144,7 @@ class UseControllerTest extends TestCase
         ));
         $response
             ->assertStatus(Response::HTTP_BAD_REQUEST)
-            ->assertJson(array("message" => "残高がマイナスです。チャージしてください。"));
+            ->assertJson(array("message" => ConstMessages::BALANCE_MINUS_MESSAGE));
         // 残高が変わっていないことを確認。
         $this->assertEquals($balance, $this->getBalanceForUser(3));
     }
@@ -162,7 +163,7 @@ class UseControllerTest extends TestCase
         ));
         $response
             ->assertStatus(Response::HTTP_BAD_REQUEST)
-            ->assertJson(array("message" => "残高がマイナスです。チャージしてください。"));
+            ->assertJson(array("message" => ConstMessages::BALANCE_MINUS_MESSAGE));
         $this->assertEquals(0, $this->getBalanceForUser(201));
     }
 

--- a/tests/Feature/UseControllerTest.php
+++ b/tests/Feature/UseControllerTest.php
@@ -1,0 +1,254 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\UsageLog;
+use Database\Seeders\UsageLogSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\TestCase;
+
+class UseControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function getBalanceForUser(int $userId): int
+    {
+        return DB::table("usage_logs")
+            ->where("user_id", $userId)
+            ->sum("changed_amount");
+    }
+
+    /**
+     * "test_post"という目的で700円使用する。
+     * UserIdの指定なし(UserId=100)での実行。
+     *
+     * レスポンスコードの確認、レスポンスに残高が含まれていることの確認、DBのレコードの目的と金額があっているかの確認。
+     * @return void
+     */
+    public function test_default_user_use_700(): void
+    {
+        // もともとの残高は1700円
+        $this->seed(UsageLogSeeder::class);
+
+        $response = $this->postJson("/api/use", array(
+            "amount" => 700,
+            "description" => "test_post",
+        ));
+        // レスポンスに残高が正しく含まれていることを確認。
+        $response
+            ->assertStatus(Response::HTTP_OK)
+            ->assertJson(array("balance" => 1000));
+
+        /** @noinspection PhpUndefinedMethodInspection */
+        $lastRecord = UsageLog::orderBy('id', 'DESC')->first();
+
+        // Assumption to get the record inserted by above code.
+        $this->assertEquals("test_post", $lastRecord->description, "test assumption");
+        $this->assertEquals(-700, $lastRecord->changed_amount);
+        $this->assertEquals(1000, $this->getBalanceForUser(100));
+    }
+
+    /**
+     * "test_post"という目的で1699円使用する。
+     * UserIdの指定なし(UserId=100)での実行。
+     * チャージのメッセージが含まれないことを確認。
+     */
+    public function test_default_user_use_1699(): void
+    {
+        // もともとの残高は1700円
+        $this->seed(UsageLogSeeder::class);
+
+        $response = $this->postJson("/api/use", array(
+            "amount" => 1699,
+            "description" => "test_post",
+        ));
+        // レスポンスに残高が正しく含まれていることを確認。またチャージのメッセージが入っていることを確認。
+        $response
+            ->assertStatus(Response::HTTP_OK)
+            ->assertJson(array(
+                "balance" => 1,
+            ))
+            ->assertJsonMissingExact(array(
+                "message" => "チャージしてください",
+            ));
+        $this->assertEquals(1, $this->getBalanceForUser(100));
+    }
+
+    /**
+     * "test_post"という目的で1700円使用する。
+     * UserIdの指定なし(UserId=100)での実行。
+     * 残高が0円になるのでチャージのメッセージが含まれるか確認。
+     */
+    public function test_default_user_use_1700(): void
+    {
+        // もともとの残高は1700円
+        $this->seed(UsageLogSeeder::class);
+
+        $response = $this->postJson("/api/use", array(
+            "amount" => 1700,
+            "description" => "test_post",
+        ));
+        // レスポンスに残高が正しく含まれていることを確認。またチャージのメッセージが入っていることを確認。
+        $response
+            ->assertStatus(Response::HTTP_OK)
+            ->assertJson(array(
+                "balance" => 0,
+                "message" => "チャージしてください",
+            ));
+        $this->assertEquals(0, $this->getBalanceForUser(100));
+    }
+
+    /**
+     * "test_post"という目的で1701円使用する。
+     * UserIdの指定なし(UserId=100)での実行。
+     * 残高が0円になるのでチャージのメッセージが含まれるか確認。
+     */
+    public function test_default_user_use_1701(): void
+    {
+        // もともとの残高は1700円
+        $this->seed(UsageLogSeeder::class);
+
+        $response = $this->postJson("/api/use", array(
+            "amount" => 1701,
+            "description" => "test_post",
+        ));
+        // レスポンスに残高が正しく含まれていることを確認。またチャージのメッセージが入っていることを確認。
+        $response
+            ->assertStatus(Response::HTTP_OK)
+            ->assertJson(array(
+                "balance" => -1,
+                "message" => "チャージしてください",
+            ));
+        $this->assertEquals(-1, $this->getBalanceForUser(100));
+    }
+
+    /**
+     * "test_post"という目的で700円使用する。
+     * UserId=3で実行。
+     * 元々の残高がマイナスなので400となる。
+     * @return void
+     */
+    public function test_user_3_use(): void
+    {
+        Config::set("app.user_id", 3);
+        $this->seed(UsageLogSeeder::class);
+        $balance = $this->getBalanceForUser(3);
+        $this->assertLessThan(0, $balance, "test assumption");
+        $response = $this->postJson("/api/use", array(
+            "amount" => 700,
+            "description" => "test_post",
+        ));
+        $response
+            ->assertStatus(Response::HTTP_BAD_REQUEST)
+            ->assertJson(array("message" => "残高がマイナスです。チャージしてください。"));
+        // 残高が変わっていないことを確認。
+        $this->assertEquals($balance, $this->getBalanceForUser(3));
+    }
+
+    /**
+     * dataなし
+     */
+    public function test_no_data(): void
+    {
+        $response = $this->postJson("/api/use");
+        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+
+    /**
+     * descriptionなし
+     */
+    public function test_no_description(): void
+    {
+        $response = $this->postJson("/api/use", array(
+            "amount" => 1000,
+        ));
+        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+
+    /**
+     * empty description
+     */
+    public function test_empty_description(): void
+    {
+        $response = $this->postJson("/api/use", array(
+            "amount" => 1000,
+            "description" => "",
+        ));
+        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+
+    /**
+     * descriptionが文字列でなく数字の時ははじく
+     */
+    public function test_number_description(): void
+    {
+        $response = $this->postJson("/api/use", array(
+            "amount" => 1000,
+            "description" => 100,
+        ));
+        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+
+    /**
+     * descriptionが数字の文字列ならOK
+     */
+    public function test_number_string_description(): void
+    {
+        $this->seed(UsageLogSeeder::class);
+        $response = $this->postJson("/api/use", array(
+            "amount" => 1000,
+            "description" => "100",
+        ));
+        $response->assertStatus(Response::HTTP_OK);
+    }
+
+    /**
+     * descriptionが文字列でなくboolの時ははじく
+     */
+    public function test_bool_description(): void
+    {
+        $response = $this->postJson("/api/use", array(
+            "amount" => 1000,
+            "description" => true,
+        ));
+        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+
+    /**
+     * amountなし
+     */
+    public function test_no_amount(): void
+    {
+        $response = $this->postJson("/api/use", array(
+            "description" => "test_no_amount",
+        ));
+        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+
+    /**
+     * amount == 0
+     */
+    public function test_amount_is_0(): void
+    {
+        $response = $this->postJson("/api/use", array(
+            "description" => "test_amount_is_0",
+            "amount" => 0,
+        ));
+        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+
+    /**
+     * amount < 0
+     */
+    public function test_amount_is_minus(): void
+    {
+        $response = $this->postJson("/api/use", array(
+            "description" => "test_amount_is_minus",
+            "amount" => -1,
+        ));
+        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+}


### PR DESCRIPTION
API Endpoint: https://www.notion.so/yumemi/api-use-f70baa8ed6534205ab87cd90624e6923
Test ref: https://www.notion.so/yumemi/688a657310294a88a029672f83cd61ab?p=befbcddbaa344b21a37755ab49610f7b&pm=s

## やったこと

* `/api/use`のコントローラーとroutingの実装
* テストコードの追加

## やらないこと

* 統合的なテストは別PRで。

## できるようになること（ユーザ目線）

* "使用"の操作ができるようになる

## できなくなること（ユーザ目線）

* なし

## 動作確認

* テストコードでの検証
  * 正常系
    * 残高が足りている場合
    * 残高が足りていない場合はチャージを促す
  * 異常系
    * 残高が0円以下の場合
    * パラメーターのバリデーションに通らない場合
      * amountの値が不正
      * descriptionがセットされていない

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
  * なし
