### PR TITLE
[Feature] Usage Log

### DIFF
--- a/app/Http/Controllers/GetUsageLogsController.php
+++ b/app/Http/Controllers/GetUsageLogsController.php
@@ -28,7 +28,7 @@ class GetUsageLogsController extends Controller
         if (array_key_exists("to", $validated)) {
             $query = $query->where("used_at", "<", $validated["to"]);
         }
-        $logs = $query->get(["id", "used_at", "changed_amount", "description"]);
+        $logs = $query->get(["used_at", "changed_amount", "description"]);
         return response()
             ->json(array(
                 "logs" => $logs,

--- a/app/Http/Controllers/GetUsageLogsController.php
+++ b/app/Http/Controllers/GetUsageLogsController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class GetUsageLogsController extends Controller
+{
+    public function getUsageLogs(Request $request): JsonResponse
+    {
+        $userId = intval(config("app.user_id"));
+        $minTime = $request->query("from");
+        $maxTime = $request->query("to");
+        $query = DB::table("usage_logs")->where("user_id", $userId);
+        if ($minTime != null) {
+            $query = $query->where("used_at", ">=", $minTime);
+        }
+        if ($maxTime != null) {
+            $query = $query->where("used_at", "<", $maxTime);
+        }
+        $logs = $query->get(["id", "used_at", "changed_amount", "description"]);
+        return response()
+            ->json(array(
+                "logs" => $logs,
+            ));
+    }
+}

--- a/app/Http/Controllers/GetUsageLogsController.php
+++ b/app/Http/Controllers/GetUsageLogsController.php
@@ -5,20 +5,28 @@ namespace App\Http\Controllers;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
 
 class GetUsageLogsController extends Controller
 {
+    private array $validationRules = [
+        "from" => ["nullable", "date"],
+        "to" => ["nullable", "date"],
+    ];
+
+    /**
+     * @throws ValidationException
+     */
     public function getUsageLogs(Request $request): JsonResponse
     {
+        $validated = $this->validate($request, $this->validationRules);
         $userId = intval(config("app.user_id"));
-        $minTime = $request->query("from");
-        $maxTime = $request->query("to");
         $query = DB::table("usage_logs")->where("user_id", $userId);
-        if ($minTime != null) {
-            $query = $query->where("used_at", ">=", $minTime);
+        if (array_key_exists("from", $validated)) {
+            $query = $query->where("used_at", ">=", $validated["from"]);
         }
-        if ($maxTime != null) {
-            $query = $query->where("used_at", "<", $maxTime);
+        if (array_key_exists("to", $validated)) {
+            $query = $query->where("used_at", "<", $validated["to"]);
         }
         $logs = $query->get(["id", "used_at", "changed_amount", "description"]);
         return response()

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,9 +1,9 @@
 <?php
 
-use App\Http\Controllers\ChargeController;
 use App\Http\Controllers\BalanceController;
-use App\Http\Controllers\UseController;
+use App\Http\Controllers\ChargeController;
 use App\Http\Controllers\GetUsageLogsController;
+use App\Http\Controllers\UseController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\ChargeController;
 use App\Http\Controllers\BalanceController;
 use App\Http\Controllers\UseController;
+use App\Http\Controllers\GetUsageLogsController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -21,6 +22,7 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
 
-Route::post("charge", [ChargeController::class, "charge"]);
 Route::get("balance", [BalanceController::class, "getBalance"]);
 Route::post("use", [UseController::class, "use"]);
+Route::post("charge", [ChargeController::class, "charge"]);
+Route::get("usage_logs", [GetUsageLogsController::class, "getUsageLogs"]);

--- a/tests/Feature/GetUsageLogsControllerTest.php
+++ b/tests/Feature/GetUsageLogsControllerTest.php
@@ -1,0 +1,338 @@
+<?php
+
+namespace Tests\Feature;
+
+use Database\Seeders\UsageLogSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\TestCase;
+
+class GetUsageLogsControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(UsageLogSeeder::class);
+    }
+
+    /**
+     * デフォルト(UserId=100)の全履歴の取得。
+     * Seederの結果とあっているか、欲しいキーは存在しているか確認する。
+     * キーはid, used_at, changed_amount, description
+     * @return void
+     */
+    public function test_default_user_get(): void
+    {
+        // "id"は一旦無視する。値が変化するため。
+        $expected = json_decode('
+        {
+          "logs": [
+            {
+              "used_at": "2023-02-01 00:00:00",
+              "changed_amount": 5000,
+              "description": "チャージ"
+            },
+            {
+              "used_at": "2023-02-01 07:00:00",
+              "changed_amount": -100,
+              "description": "アイス"
+            },
+            {
+              "used_at": "2023-02-01 12:00:00",
+              "changed_amount": -800,
+              "description": "ラーメン"
+            },
+            {
+              "used_at": "2023-02-01 18:00:00",
+              "changed_amount": -600,
+              "description": "たこ焼き"
+            },
+            {
+              "used_at": "2023-02-02 07:30:00",
+              "changed_amount": -200,
+              "description": "アイス"
+            },
+            {
+              "used_at": "2023-02-02 12:30:00",
+              "changed_amount": -600,
+              "description": "たこ焼き"
+            },
+            {
+              "used_at": "2023-02-02 17:30:00",
+              "changed_amount": -1000,
+              "description": "ラーメン"
+            }
+          ]
+        }', true);
+        $this->assertNotNull($expected, "Assumption failed");
+        $request = $this->get("/api/usage_logs");
+        $request
+            ->assertStatus(Response::HTTP_OK)
+            ->assertJson($expected);
+        // Idのキーがあることを確認
+        foreach ($request->json("logs") as $value) {
+            $this->assertArrayHasKey("id", $value);
+        }
+        $this->assertSameSize($expected["logs"], $request->json("logs"));
+    }
+
+    /**
+     * UserId=201の履歴取得。このユーザーは空の履歴となる。
+     * @return void
+     */
+    public function test_user_201_get(): void
+    {
+        Config::set("app.user_id", 201);
+        $expected = json_decode('{"logs": []}', true);
+        $this->assertNotNull($expected, "Assumption failed");
+        $request = $this->get("/api/usage_logs");
+        $request
+            ->assertStatus(Response::HTTP_OK)
+            ->assertExactJson($expected);
+        $this->assertSameSize($expected["logs"], $request->json("logs"));
+    }
+
+    /**
+     * UserId=2の履歴取得。
+     * Seederで入れたデータが全て入っているか確認。
+     * @return void
+     */
+    public function test_user_2_get(): void
+    {
+        Config::set("app.user_id", 2);
+        $expected = json_decode('
+        {
+          "logs": [
+            {
+              "used_at": "2023-02-04 00:00:00",
+              "changed_amount": 2000,
+              "description": "チャージ"
+            },
+            {
+              "used_at": "2023-02-05 07:00:00",
+              "changed_amount": -100,
+              "description": "チョコレート"
+            },
+            {
+              "used_at": "2023-02-05 12:00:00",
+              "changed_amount": -800,
+              "description": "ラーメン"
+            },
+            {
+              "used_at": "2023-02-05 12:00:00",
+              "changed_amount": 3000,
+              "description": "チャージ"
+            },
+            {
+              "used_at": "2023-02-05 18:00:00",
+              "changed_amount": -600,
+              "description": "たこ焼き"
+            },
+            {
+              "used_at": "2023-02-08 07:30:00",
+              "changed_amount": -200,
+              "description": "チョコレート"
+            },
+            {
+              "used_at": "2023-02-09 12:30:00",
+              "changed_amount": -600,
+              "description": "たこ焼き"
+            },
+            {
+              "used_at": "2023-02-10 17:30:00",
+              "changed_amount": -500,
+              "description": "たこ焼き"
+            }
+          ]
+        }
+        ', true);
+        $this->assertNotNull($expected, "Assumption failed");
+        $request = $this->get("/api/usage_logs");
+        $request
+            ->assertStatus(Response::HTTP_OK)
+            ->assertJson($expected);
+        $this->assertSameSize($expected["logs"], $request->json("logs"));
+    }
+
+    /**
+     * 無効な期間設定をした場合は空の値が返却される。
+     */
+    public function test_invalid_clip(): void
+    {
+        $expected = json_decode('{"logs": []}', true);
+        $this->assertNotNull($expected, "Assumption failed");
+        $request = $this->get("/api/usage_logs?from=2023-02-01T00:00:00&to=2023-01-01T00:00:00");
+        $request
+            ->assertStatus(Response::HTTP_OK)
+            ->assertExactJson($expected);
+        $this->assertSameSize($expected["logs"], $request->json("logs"));
+    }
+
+    /**
+     * From: 2/1, To: 2/2の取得(UserId=100)
+     */
+    public function test_get_from0221_to0222(): void
+    {
+        $expected = json_decode('
+        {
+          "logs": [
+            {
+              "used_at": "2023-02-01 00:00:00",
+              "changed_amount": 5000,
+              "description": "チャージ"
+            },
+            {
+              "used_at": "2023-02-01 07:00:00",
+              "changed_amount": -100,
+              "description": "アイス"
+            },
+            {
+              "used_at": "2023-02-01 12:00:00",
+              "changed_amount": -800,
+              "description": "ラーメン"
+            },
+            {
+              "used_at": "2023-02-01 18:00:00",
+              "changed_amount": -600,
+              "description": "たこ焼き"
+            }
+          ]
+        }', true);
+        $this->assertNotNull($expected, "Assumption failed");
+        $request = $this->get("/api/usage_logs?from=2023-02-01T00:00:00&to=2023-02-02T00:00:00");
+        $request
+            ->assertStatus(Response::HTTP_OK)
+            ->assertJson($expected);
+        $this->assertSameSize($expected["logs"], $request->json("logs"));
+    }
+
+    /**
+     * From: 2/1 00:00, To: 2/1 12:00の取得(UserId=100)
+     * 12:00のデータが入っていないことを確認。
+     * FromはInclusiveなので00:00のデータは入っている。
+     */
+    public function test_get_from0221T0000_to0221T1200(): void
+    {
+        $expected = json_decode('
+        {
+          "logs": [
+            {
+              "used_at": "2023-02-01 00:00:00",
+              "changed_amount": 5000,
+              "description": "チャージ"
+            },
+            {
+              "used_at": "2023-02-01 07:00:00",
+              "changed_amount": -100,
+              "description": "アイス"
+            }
+          ]
+        }', true);
+        $this->assertNotNull($expected, "Assumption failed");
+        $request = $this->get("/api/usage_logs?from=2023-02-01T00:00:00&to=2023-02-01T12:00:00");
+        $request
+            ->assertStatus(Response::HTTP_OK)
+            ->assertJson($expected);
+        $this->assertSameSize($expected["logs"], $request->json("logs"));
+    }
+
+    /**
+     * To: 2/1 12:00の取得(UserId=100)
+     * Toのみの指定
+     */
+    public function test_get_to0221T1200(): void
+    {
+        $expected = json_decode('
+        {
+          "logs": [
+            {
+              "used_at": "2023-02-01 00:00:00",
+              "changed_amount": 5000,
+              "description": "チャージ"
+            },
+            {
+              "used_at": "2023-02-01 07:00:00",
+              "changed_amount": -100,
+              "description": "アイス"
+            }
+          ]
+        }', true);
+        $this->assertNotNull($expected, "Assumption failed");
+        $request = $this->get("/api/usage_logs?to=2023-02-01T12:00:00");
+        $request
+            ->assertStatus(Response::HTTP_OK)
+            ->assertJson($expected);
+        $this->assertSameSize($expected["logs"], $request->json("logs"));
+    }
+
+    /**
+     * From: 2/2 7:30の取得(UserId=100)
+     * Toのみの指定
+     */
+    public function test_get_from0221T1200(): void
+    {
+        $expected = json_decode('
+        {
+          "logs": [
+            {
+              "used_at": "2023-02-02 07:30:00",
+              "changed_amount": -200,
+              "description": "アイス"
+            },
+            {
+              "used_at": "2023-02-02 12:30:00",
+              "changed_amount": -600,
+              "description": "たこ焼き"
+            },
+            {
+              "used_at": "2023-02-02 17:30:00",
+              "changed_amount": -1000,
+              "description": "ラーメン"
+            }
+          ]
+        }', true);
+        $this->assertNotNull($expected, "Assumption failed");
+        $request = $this->get("/api/usage_logs?from=2023-02-02T07:30:00");
+        $request
+            ->assertStatus(Response::HTTP_OK)
+            ->assertJson($expected);
+        $this->assertSameSize($expected["logs"], $request->json("logs"));
+    }
+
+    /**
+     * From: 2/1 00:00, To: 2/1 12:01の取得(UserId=100)
+     * 12:00のデータが入っていることを確認
+     */
+    public function test_get_from0221T0000_to0221T1201(): void
+    {
+        $expected = json_decode('
+        {
+          "logs": [
+            {
+              "used_at": "2023-02-01 00:00:00",
+              "changed_amount": 5000,
+              "description": "チャージ"
+            },
+            {
+              "used_at": "2023-02-01 07:00:00",
+              "changed_amount": -100,
+              "description": "アイス"
+            },
+            {
+              "used_at": "2023-02-01 12:00:00",
+              "changed_amount": -800,
+              "description": "ラーメン"
+            }
+          ]
+        }', true);
+        $this->assertNotNull($expected, "Assumption failed");
+        $request = $this->get("/api/usage_logs?from=2023-02-01T00:00:00&to=2023-02-01T12:01:00");
+        $request
+            ->assertStatus(Response::HTTP_OK)
+            ->assertJson($expected);
+        $this->assertSameSize($expected["logs"], $request->json("logs"));
+    }
+}

--- a/tests/Feature/GetUsageLogsControllerTest.php
+++ b/tests/Feature/GetUsageLogsControllerTest.php
@@ -304,7 +304,7 @@ class GetUsageLogsControllerTest extends TestCase
 
     /**
      * From: 2/2 7:30の取得(UserId=100)
-     * Toのみの指定
+     * Fromのみの指定
      */
     public function test_get_from0221t1200(): void
     {

--- a/tests/Feature/GetUsageLogsControllerTest.php
+++ b/tests/Feature/GetUsageLogsControllerTest.php
@@ -369,4 +369,13 @@ class GetUsageLogsControllerTest extends TestCase
             ->assertJson($expected);
         $this->assertSameSize($expected["logs"], $request->json("logs"));
     }
+
+    /**
+     * 無効な日付の場合
+     */
+    public function test_invalid_from_date(): void
+    {
+        $request = $this->getJson("/api/usage_logs?from=hey");
+        $request->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
 }

--- a/tests/Feature/GetUsageLogsControllerTest.php
+++ b/tests/Feature/GetUsageLogsControllerTest.php
@@ -210,6 +210,40 @@ class GetUsageLogsControllerTest extends TestCase
     }
 
     /**
+     * FromとToがデータの範囲内の場合にフィルタしているかの確認
+     * @return void
+     */
+    public function test_get_from0221t1200_to0222t1200(): void
+    {
+        $expected = json_decode('
+        {
+          "logs": [
+            {
+              "used_at": "2023-02-01 12:00:00",
+              "changed_amount": -800,
+              "description": "ラーメン"
+            },
+            {
+              "used_at": "2023-02-01 18:00:00",
+              "changed_amount": -600,
+              "description": "たこ焼き"
+            },
+            {
+              "used_at": "2023-02-02 07:30:00",
+              "changed_amount": -200,
+              "description": "アイス"
+            }
+          ]
+        }', true);
+        $this->assertNotNull($expected, "Assumption failed");
+        $request = $this->get("/api/usage_logs?from=2023-02-01T12:00:00&to=2023-02-02T12:00:00");
+        $request
+            ->assertStatus(Response::HTTP_OK)
+            ->assertJson($expected);
+        $this->assertSameSize($expected["logs"], $request->json("logs"));
+    }
+
+    /**
      * From: 2/1 00:00, To: 2/1 12:00の取得(UserId=100)
      * 12:00のデータが入っていないことを確認。
      * FromはInclusiveなので00:00のデータは入っている。

--- a/tests/Feature/GetUsageLogsControllerTest.php
+++ b/tests/Feature/GetUsageLogsControllerTest.php
@@ -21,12 +21,11 @@ class GetUsageLogsControllerTest extends TestCase
     /**
      * デフォルト(UserId=100)の全履歴の取得。
      * Seederの結果とあっているか、欲しいキーは存在しているか確認する。
-     * キーはid, used_at, changed_amount, description
+     * キーはused_at, changed_amount, description
      * @return void
      */
     public function test_default_user_get(): void
     {
-        // "id"は一旦無視する。値が変化するため。
         $expected = json_decode('
         {
           "logs": [
@@ -71,11 +70,8 @@ class GetUsageLogsControllerTest extends TestCase
         $request = $this->get("/api/usage_logs");
         $request
             ->assertStatus(Response::HTTP_OK)
-            ->assertJson($expected);
-        // Idのキーがあることを確認
-        foreach ($request->json("logs") as $value) {
-            $this->assertArrayHasKey("id", $value);
-        }
+            ->assertExactJson($expected);
+
         $this->assertSameSize($expected["logs"], $request->json("logs"));
     }
 
@@ -153,7 +149,7 @@ class GetUsageLogsControllerTest extends TestCase
         $request = $this->get("/api/usage_logs");
         $request
             ->assertStatus(Response::HTTP_OK)
-            ->assertJson($expected);
+            ->assertExactJson($expected);
         $this->assertSameSize($expected["logs"], $request->json("logs"));
     }
 
@@ -205,7 +201,7 @@ class GetUsageLogsControllerTest extends TestCase
         $request = $this->get("/api/usage_logs?from=2023-02-01T00:00:00&to=2023-02-02T00:00:00");
         $request
             ->assertStatus(Response::HTTP_OK)
-            ->assertJson($expected);
+            ->assertExactJson($expected);
         $this->assertSameSize($expected["logs"], $request->json("logs"));
     }
 
@@ -239,7 +235,7 @@ class GetUsageLogsControllerTest extends TestCase
         $request = $this->get("/api/usage_logs?from=2023-02-01T12:00:00&to=2023-02-02T12:00:00");
         $request
             ->assertStatus(Response::HTTP_OK)
-            ->assertJson($expected);
+            ->assertExactJson($expected);
         $this->assertSameSize($expected["logs"], $request->json("logs"));
     }
 
@@ -269,7 +265,7 @@ class GetUsageLogsControllerTest extends TestCase
         $request = $this->get("/api/usage_logs?from=2023-02-01T00:00:00&to=2023-02-01T12:00:00");
         $request
             ->assertStatus(Response::HTTP_OK)
-            ->assertJson($expected);
+            ->assertExactJson($expected);
         $this->assertSameSize($expected["logs"], $request->json("logs"));
     }
 
@@ -298,7 +294,7 @@ class GetUsageLogsControllerTest extends TestCase
         $request = $this->get("/api/usage_logs?to=2023-02-01T12:00:00");
         $request
             ->assertStatus(Response::HTTP_OK)
-            ->assertJson($expected);
+            ->assertExactJson($expected);
         $this->assertSameSize($expected["logs"], $request->json("logs"));
     }
 
@@ -332,7 +328,7 @@ class GetUsageLogsControllerTest extends TestCase
         $request = $this->get("/api/usage_logs?from=2023-02-02T07:30:00");
         $request
             ->assertStatus(Response::HTTP_OK)
-            ->assertJson($expected);
+            ->assertExactJson($expected);
         $this->assertSameSize($expected["logs"], $request->json("logs"));
     }
 
@@ -366,7 +362,7 @@ class GetUsageLogsControllerTest extends TestCase
         $request = $this->get("/api/usage_logs?from=2023-02-01T00:00:00&to=2023-02-01T12:01:00");
         $request
             ->assertStatus(Response::HTTP_OK)
-            ->assertJson($expected);
+            ->assertExactJson($expected);
         $this->assertSameSize($expected["logs"], $request->json("logs"));
     }
 

--- a/tests/Feature/GetUsageLogsControllerTest.php
+++ b/tests/Feature/GetUsageLogsControllerTest.php
@@ -248,7 +248,7 @@ class GetUsageLogsControllerTest extends TestCase
      * 12:00のデータが入っていないことを確認。
      * FromはInclusiveなので00:00のデータは入っている。
      */
-    public function test_get_from0221T0000_to0221T1200(): void
+    public function test_get_from0221t0000_to0221t1200(): void
     {
         $expected = json_decode('
         {
@@ -277,7 +277,7 @@ class GetUsageLogsControllerTest extends TestCase
      * To: 2/1 12:00の取得(UserId=100)
      * Toのみの指定
      */
-    public function test_get_to0221T1200(): void
+    public function test_get_to0221t1200(): void
     {
         $expected = json_decode('
         {
@@ -306,7 +306,7 @@ class GetUsageLogsControllerTest extends TestCase
      * From: 2/2 7:30の取得(UserId=100)
      * Toのみの指定
      */
-    public function test_get_from0221T1200(): void
+    public function test_get_from0221t1200(): void
     {
         $expected = json_decode('
         {
@@ -340,7 +340,7 @@ class GetUsageLogsControllerTest extends TestCase
      * From: 2/1 00:00, To: 2/1 12:01の取得(UserId=100)
      * 12:00のデータが入っていることを確認
      */
-    public function test_get_from0221T0000_to0221T1201(): void
+    public function test_get_from0221t0000_to0221t1201(): void
     {
         $expected = json_decode('
         {


### PR DESCRIPTION
API Endpoint
* クエリなし
  * https://www.notion.so/yumemi/api-usage_logs-8a25137f154e4ba48d62a3bddf6927ca
* クエリあり
  * https://www.notion.so/yumemi/api-usage_logs-1dbdd97d07b04dcbbcb0a499925b99c3

Test: https://www.notion.so/yumemi/688a657310294a88a029672f83cd61ab?p=607257b85826407d95853b11fdb5a096&pm=s

## やったこと

* `api/usage_logs`の実装
* テストコードの作成

## やらないこと

* なし

## できるようになること（ユーザ目線）

* これまでの履歴が取得できる。
* 期間を指定した履歴の取得が可能になる

## できなくなること（ユーザ目線）

* なし

## 動作確認

* テストコードによって確認
  * `id`, `used_at`, `changed_amount`, `description`が含まれていることを確認
  * Seederで入れたデータを手元でJSONにしハードコード化。その結果と比較している。
* 期間指定無し
* Fromのみ
* Toのみ
* From, Toの両方
* ユーザーの指定

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
  * [Q]今回はidをレスポンスに含めましたが、実態はAuto IncrementalなDB内の管理のみに使用される(と思われる)値なので本来はユーザー側に見せる値ではないような...?
    * idはレスポンスから削除してもOK?
  * [Q] 今回はハードコードしてますが、レスポンスのJSONは外に保存できそうです。その場合のリソースはどこに保存するべきでしょうか?
  * [Q] 今回はレスポンスに日本語が含まれています。JSON内の日本語箇所はエスケープされているのですが、このままにしておいて大丈夫でしょうか?
    * エスケープされていてもFireFoxやjqやテストコードでは戻してくれる
