### PR TITLE
Refactor/fix type Use int to calculate new balance in `charge` and `use`

### DIFF
--- a/app/Http/Controllers/BalanceController.php
+++ b/app/Http/Controllers/BalanceController.php
@@ -13,12 +13,11 @@ class BalanceController extends Controller
     {
         $userId = intval(config(UserConstant::USER_ID_KEY));
         Log::info("Start to get balance", ["user" => $userId]);
-        /** @noinspection PhpUndefinedMethodInspection (`where` should be callable.) */
-        $balance = UsageLog::where("user_id", $userId)->sum("changed_amount");
+        $balance = UsageLog::getUserBalance($userId);
         Log::info("Got balance", ["user" => $userId, "balance" => intval($balance),]);
         return response()
             ->json(array(
-                "balance" => intval($balance),
+                "balance" => $balance,
             ));
     }
 }

--- a/app/Http/Controllers/ChargeController.php
+++ b/app/Http/Controllers/ChargeController.php
@@ -40,8 +40,7 @@ class ChargeController extends Controller
         Log::debug("Charged", ["user" => $userId, "amount" => $chargeValue,]);
 
         // 返却値用の残高取得
-        /** @noinspection PhpUndefinedMethodInspection (`where` should be callable.) */
-        $balance = UsageLog::where("user_id", $userId)->sum("changed_amount");
+        $balance = UsageLog::getUserBalance($userId);
         $returnValue = array(
             "balance" => $balance,
         );

--- a/app/Http/Controllers/UseController.php
+++ b/app/Http/Controllers/UseController.php
@@ -28,8 +28,7 @@ class UseController extends Controller
 
         $userId = intval(config("app.user_id"));
         Log::info("Start to use", ["user" => $userId,]);
-        /** @noinspection PhpUndefinedMethodInspection (`where` should be callable.) */
-        $balance = UsageLog::where("user_id", $userId)->sum("changed_amount");
+        $balance = UsageLog::getUserBalance($userId);
         // 残高が0円以下なら使用しない。チャージを促して400を返す。
         if ($balance <= 0) {
             Log::info("Reject use because of insufficient balance", [

--- a/app/Models/UsageLog.php
+++ b/app/Models/UsageLog.php
@@ -21,4 +21,10 @@ class UsageLog extends Model
         "changed_amount",
         "description",
     ];
+
+    public static function getUserBalance(int $userId): int
+    {
+        /** @noinspection PhpUndefinedMethodInspection (`where` should be callable.) */
+        return intval(UsageLog::where("user_id", $userId)->sum("changed_amount"));
+    }
 }

--- a/tests/Feature/BalanceControllerTest.php
+++ b/tests/Feature/BalanceControllerTest.php
@@ -32,6 +32,17 @@ class BalanceControllerTest extends TestCase
     }
 
     /**
+     * レスポンスのbalanceがintであることを確認
+     */
+    public function test_response_has_int(): void
+    {
+        $response = $this->get("/api/balance");
+        $response->assertStatus(200);
+        $balance = $response->json("balance");
+        $this->assertIsInt($balance, "Response is expected to be an Int");
+    }
+
+    /**
      * Seederで流し込まれているユーザーの残高を取得する。
      * UserId=2での実行。
      * 別ユーザーの結果が計算に紛れていないかの確認。

--- a/tests/Feature/BalanceControllerTest.php
+++ b/tests/Feature/BalanceControllerTest.php
@@ -28,7 +28,7 @@ class BalanceControllerTest extends TestCase
         $response = $this->get("/api/balance");
         $response
             ->assertStatus(200)
-            ->assertJson(["balance" => 1700]);
+            ->assertJson(["balance" => 1700], true);
     }
 
     /**
@@ -43,7 +43,7 @@ class BalanceControllerTest extends TestCase
         $response = $this->get("/api/balance");
         $response
             ->assertStatus(200)
-            ->assertJson(["balance" => 2200]);
+            ->assertJson(["balance" => 2200], true);
     }
 
     /**
@@ -58,7 +58,7 @@ class BalanceControllerTest extends TestCase
         $response = $this->get("/api/balance");
         $response
             ->assertStatus(200)
-            ->assertJson(["balance" => -500]);
+            ->assertJson(["balance" => -500], true);
     }
 
     /**
@@ -72,6 +72,6 @@ class BalanceControllerTest extends TestCase
         $response = $this->get("/api/balance");
         $response
             ->assertStatus(200)
-            ->assertJson(["balance" => 0]);
+            ->assertJson(["balance" => 0], true);
     }
 }

--- a/tests/Feature/BalanceControllerTest.php
+++ b/tests/Feature/BalanceControllerTest.php
@@ -32,17 +32,6 @@ class BalanceControllerTest extends TestCase
     }
 
     /**
-     * レスポンスのbalanceがintであることを確認
-     */
-    public function test_response_has_int(): void
-    {
-        $response = $this->get("/api/balance");
-        $response->assertStatus(200);
-        $balance = $response->json("balance");
-        $this->assertIsInt($balance, "Response is expected to be an Int");
-    }
-
-    /**
      * Seederで流し込まれているユーザーの残高を取得する。
      * UserId=2での実行。
      * 別ユーザーの結果が計算に紛れていないかの確認。

--- a/tests/Feature/ChargeTest.php
+++ b/tests/Feature/ChargeTest.php
@@ -28,7 +28,7 @@ class ChargeTest extends TestCase
         ]);
         $response
             ->assertStatus(200)
-            ->assertJson(["balance" => 1]);
+            ->assertJson(["balance" => 1], true);
 
         // DB内でdescriptionがチャージになっているか確認
         /** @noinspection PhpUndefinedMethodInspection */
@@ -49,7 +49,7 @@ class ChargeTest extends TestCase
         ]);
         $response
             ->assertStatus(200)
-            ->assertJson(["balance" => 500]);
+            ->assertJson(["balance" => 500], true);
 
         // 2回目。1000円になるはず。
         $response = $this->postJson("/api/charge", [
@@ -57,7 +57,7 @@ class ChargeTest extends TestCase
         ]);
         $response
             ->assertStatus(200)
-            ->assertJson(["balance" => 1000]);
+            ->assertJson(["balance" => 1000], true);
         // 実際の残高が1000円になっていることを確認。
         $this->assertEquals(1000, UsageLog::getUserBalance(100));
     }
@@ -77,7 +77,7 @@ class ChargeTest extends TestCase
         ]);
         $response
             ->assertStatus(200)
-            ->assertJson(["balance" => 500]);
+            ->assertJson(["balance" => 500], true);
 
         // DB内でdescriptionがチャージになっているか確認
         /** @noinspection PhpUndefinedMethodInspection */
@@ -90,7 +90,7 @@ class ChargeTest extends TestCase
         ]);
         $response
             ->assertStatus(200)
-            ->assertJson(["balance" => 2000]);
+            ->assertJson(["balance" => 2000], true);
 
         // 別ユーザーのDBに変更がないか確認
         $this->assertEquals(1700, UsageLog::getUserBalance(100));
@@ -115,7 +115,7 @@ class ChargeTest extends TestCase
         ]);
         $response
             ->assertStatus(200)
-            ->assertJson(["balance" => 3700]);
+            ->assertJson(["balance" => 3700], true);
     }
 
     /**
@@ -132,7 +132,7 @@ class ChargeTest extends TestCase
         ]);
         $response
             ->assertStatus(200)
-            ->assertJson(["balance" => 500])
+            ->assertJson(["balance" => 500], true)
             ->assertJsonMissingExact(["message" => ConstMessages::CHARGE_SUGGESTION_MESSAGE]);
     }
 
@@ -150,7 +150,7 @@ class ChargeTest extends TestCase
         ]);
         $response
             ->assertStatus(200)
-            ->assertJson(["balance" => 0, "message" => ConstMessages::CHARGE_SUGGESTION_MESSAGE]);
+            ->assertJson(["balance" => 0, "message" => ConstMessages::CHARGE_SUGGESTION_MESSAGE], true);
     }
 
     /**
@@ -167,7 +167,7 @@ class ChargeTest extends TestCase
         ]);
         $response
             ->assertStatus(200)
-            ->assertJson(["balance" => -1, "message" => ConstMessages::CHARGE_SUGGESTION_MESSAGE]);
+            ->assertJson(["balance" => -1, "message" => ConstMessages::CHARGE_SUGGESTION_MESSAGE], true);
     }
 
     /**
@@ -181,7 +181,7 @@ class ChargeTest extends TestCase
         ]);
         $response
             ->assertStatus(200)
-            ->assertJson(["balance" => 300]);
+            ->assertJson(["balance" => 300], true);
     }
 
     /**

--- a/tests/Feature/ChargeTest.php
+++ b/tests/Feature/ChargeTest.php
@@ -38,6 +38,19 @@ class ChargeTest extends TestCase
     }
 
     /**
+     * レスポンスのbalanceがintであることを確認
+     */
+    public function test_response_has_int(): void
+    {
+        $response = $this->postJson("/api/charge", [
+            "amount" => 1
+        ]);
+        $response->assertStatus(200);
+        $balance = $response->json("balance");
+        $this->assertIsInt($balance, "Response is expected to be an Int");
+    }
+
+    /**
      * UserIdの指定なしでチャージを2回行う。
      * Seederの実行はないので初期値は0。
      * @return void

--- a/tests/Feature/ChargeTest.php
+++ b/tests/Feature/ChargeTest.php
@@ -38,19 +38,6 @@ class ChargeTest extends TestCase
     }
 
     /**
-     * レスポンスのbalanceがintであることを確認
-     */
-    public function test_response_has_int(): void
-    {
-        $response = $this->postJson("/api/charge", [
-            "amount" => 1
-        ]);
-        $response->assertStatus(200);
-        $balance = $response->json("balance");
-        $this->assertIsInt($balance, "Response is expected to be an Int");
-    }
-
-    /**
      * UserIdの指定なしでチャージを2回行う。
      * Seederの実行はないので初期値は0。
      * @return void

--- a/tests/Feature/Models/UsageLogTest.php
+++ b/tests/Feature/Models/UsageLogTest.php
@@ -18,20 +18,6 @@ class UsageLogTest extends TestCase
     }
 
     /**
-     * UsageLog::getUserBalanceがintを返すことを確認する
-     * 何も入っていないユーザー(99)、残高がマイナスのユーザー(3)、プラスのユーザー(100)で検証
-     *
-     * @dataProvider userIdAndBalance
-     * @param int $userId
-     * @return void
-     */
-    public function test_get_balance_return_type(int $userId): void
-    {
-        $this->assertIsInt(UsageLog::getUserBalance($userId),
-            "User $userId");
-    }
-
-    /**
      * 指定したユーザーの残高が正確に取得できていることを確認する
      * 何も入っていないユーザー(99)、残高がマイナスのユーザー(3)、プラスのユーザー(100)で検証
      *
@@ -42,7 +28,7 @@ class UsageLogTest extends TestCase
      */
     public function test_get_balance(int $userId, int $expectedBalance): void
     {
-        $this->assertEquals($expectedBalance, UsageLog::getUserBalance($userId),
+        $this->assertSame($expectedBalance, UsageLog::getUserBalance($userId),
             "User $userId");
     }
 

--- a/tests/Feature/Models/UsageLogTest.php
+++ b/tests/Feature/Models/UsageLogTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tests\Feature\Models;
+
+use App\Models\UsageLog;
+use Database\Seeders\UsageLogSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class UsageLogTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * UsageLog::getUserBalanceがintを返すことを確認する
+     * 何も入っていないユーザー(0)、残高がマイナスのユーザー(3)、プラスのユーザー(100)で検証
+     * @return void
+     */
+    public function test_get_balance_return_type(): void
+    {
+        $this->seed(UsageLogSeeder::class);
+        foreach ([0, 3, 100] as $userId) {
+            $this->assertIsInt(UsageLog::getUserBalance($userId));
+        }
+    }
+
+}

--- a/tests/Feature/Models/UsageLogTest.php
+++ b/tests/Feature/Models/UsageLogTest.php
@@ -11,17 +11,48 @@ class UsageLogTest extends TestCase
 {
     use RefreshDatabase;
 
-    /**
-     * UsageLog::getUserBalanceがintを返すことを確認する
-     * 何も入っていないユーザー(0)、残高がマイナスのユーザー(3)、プラスのユーザー(100)で検証
-     * @return void
-     */
-    public function test_get_balance_return_type(): void
+    protected function setUp(): void
     {
+        parent::setUp();
         $this->seed(UsageLogSeeder::class);
-        foreach ([0, 3, 100] as $userId) {
-            $this->assertIsInt(UsageLog::getUserBalance($userId));
-        }
     }
 
+    /**
+     * UsageLog::getUserBalanceがintを返すことを確認する
+     * 何も入っていないユーザー(99)、残高がマイナスのユーザー(3)、プラスのユーザー(100)で検証
+     *
+     * @dataProvider userIdAndBalance
+     * @param int $userId
+     * @return void
+     */
+    public function test_get_balance_return_type(int $userId): void
+    {
+        $this->assertIsInt(UsageLog::getUserBalance($userId),
+            "User $userId");
+    }
+
+    /**
+     * 指定したユーザーの残高が正確に取得できていることを確認する
+     * 何も入っていないユーザー(99)、残高がマイナスのユーザー(3)、プラスのユーザー(100)で検証
+     *
+     * @dataProvider userIdAndBalance
+     * @param int $userId
+     * @param int $expectedBalance
+     * @return void
+     */
+    public function test_get_balance(int $userId, int $expectedBalance): void
+    {
+        $this->assertEquals($expectedBalance, UsageLog::getUserBalance($userId),
+            "User $userId");
+    }
+
+    public function userIdAndBalance(): array
+    {
+        // array of userId, expected-Balance
+        return array(
+            [100, 1700],  // default user with plus balance
+            [99, 0], // not existing user
+            [3, -500],  // minus balance
+        );
+    }
 }

--- a/tests/Feature/UseControllerTest.php
+++ b/tests/Feature/UseControllerTest.php
@@ -33,7 +33,7 @@ class UseControllerTest extends TestCase
         // レスポンスに残高が正しく含まれていることを確認。
         $response
             ->assertStatus(Response::HTTP_OK)
-            ->assertJson(array("balance" => 1000));
+            ->assertJson(array("balance" => 1000), true);
 
         /** @noinspection PhpUndefinedMethodInspection */
         $lastRecord = UsageLog::orderBy('id', 'DESC')->first();
@@ -136,7 +136,7 @@ class UseControllerTest extends TestCase
         ));
         $response
             ->assertStatus(Response::HTTP_BAD_REQUEST)
-            ->assertJson(array("message" => ConstMessages::BALANCE_MINUS_MESSAGE));
+            ->assertJson(array("message" => ConstMessages::BALANCE_MINUS_MESSAGE), true);
         // 残高が変わっていないことを確認。
         $this->assertEquals($balance, UsageLog::getUserBalance(3));
     }
@@ -155,7 +155,7 @@ class UseControllerTest extends TestCase
         ));
         $response
             ->assertStatus(Response::HTTP_BAD_REQUEST)
-            ->assertJson(array("message" => ConstMessages::BALANCE_MINUS_MESSAGE));
+            ->assertJson(array("message" => ConstMessages::BALANCE_MINUS_MESSAGE), true);
         $this->assertEquals(0, UsageLog::getUserBalance(201));
     }
 

--- a/tests/Feature/UseControllerTest.php
+++ b/tests/Feature/UseControllerTest.php
@@ -45,6 +45,21 @@ class UseControllerTest extends TestCase
     }
 
     /**
+     * レスポンスのbalanceがintであることを確認
+     */
+    public function test_response_has_int(): void
+    {
+        $this->seed(UsageLogSeeder::class);
+        $response = $this->postJson("/api/use", [
+            "amount" => 1,
+            "description" => __FUNCTION__,
+        ]);
+        $response->assertStatus(200);
+        $balance = $response->json("balance");
+        $this->assertIsInt($balance, "Response is expected to be an Int");
+    }
+
+    /**
      * "test_post"という目的で1699円使用する。
      * UserIdの指定なし(UserId=100)での実行。
      * チャージのメッセージが含まれないことを確認。

--- a/tests/Feature/UseControllerTest.php
+++ b/tests/Feature/UseControllerTest.php
@@ -45,21 +45,6 @@ class UseControllerTest extends TestCase
     }
 
     /**
-     * レスポンスのbalanceがintであることを確認
-     */
-    public function test_response_has_int(): void
-    {
-        $this->seed(UsageLogSeeder::class);
-        $response = $this->postJson("/api/use", [
-            "amount" => 1,
-            "description" => __FUNCTION__,
-        ]);
-        $response->assertStatus(200);
-        $balance = $response->json("balance");
-        $this->assertIsInt($balance, "Response is expected to be an Int");
-    }
-
-    /**
      * "test_post"という目的で1699円使用する。
      * UserIdの指定なし(UserId=100)での実行。
      * チャージのメッセージが含まれないことを確認。

--- a/tests/Feature/UseControllerTest.php
+++ b/tests/Feature/UseControllerTest.php
@@ -39,9 +39,9 @@ class UseControllerTest extends TestCase
         $lastRecord = UsageLog::orderBy('id', 'DESC')->first();
 
         // Assumption to get the record inserted by above code.
-        $this->assertEquals("test_post", $lastRecord->description, "test assumption");
-        $this->assertEquals(-700, $lastRecord->changed_amount);
-        $this->assertEquals(1000, UsageLog::getUserBalance(100));
+        $this->assertSame("test_post", $lastRecord->description, "test assumption");
+        $this->assertSame(-700, $lastRecord->changed_amount);
+        $this->assertSame(1000, UsageLog::getUserBalance(100));
     }
 
     /**
@@ -67,7 +67,7 @@ class UseControllerTest extends TestCase
             ->assertJsonMissingExact(array(
                 "message" => ConstMessages::CHARGE_SUGGESTION_MESSAGE,
             ));
-        $this->assertEquals(1, UsageLog::getUserBalance(100));
+        $this->assertSame(1, UsageLog::getUserBalance(100));
     }
 
     /**
@@ -91,7 +91,7 @@ class UseControllerTest extends TestCase
                 "balance" => 0,
                 "message" => ConstMessages::CHARGE_SUGGESTION_MESSAGE,
             ));
-        $this->assertEquals(0, UsageLog::getUserBalance(100));
+        $this->assertSame(0, UsageLog::getUserBalance(100));
     }
 
     /**
@@ -115,7 +115,7 @@ class UseControllerTest extends TestCase
                 "balance" => -1,
                 "message" => ConstMessages::CHARGE_SUGGESTION_MESSAGE,
             ));
-        $this->assertEquals(-1, UsageLog::getUserBalance(100));
+        $this->assertSame(-1, UsageLog::getUserBalance(100));
     }
 
     /**
@@ -138,7 +138,7 @@ class UseControllerTest extends TestCase
             ->assertStatus(Response::HTTP_BAD_REQUEST)
             ->assertJson(array("message" => ConstMessages::BALANCE_MINUS_MESSAGE), true);
         // 残高が変わっていないことを確認。
-        $this->assertEquals($balance, UsageLog::getUserBalance(3));
+        $this->assertSame($balance, UsageLog::getUserBalance(3));
     }
 
     /**
@@ -156,7 +156,7 @@ class UseControllerTest extends TestCase
         $response
             ->assertStatus(Response::HTTP_BAD_REQUEST)
             ->assertJson(array("message" => ConstMessages::BALANCE_MINUS_MESSAGE), true);
-        $this->assertEquals(0, UsageLog::getUserBalance(201));
+        $this->assertSame(0, UsageLog::getUserBalance(201));
     }
 
     /**


### PR DESCRIPTION
## やったこと

* DBから残高を計算する処理を`UsageLog`にメソッドとして定義
* 残高の計算時にintになっている部分とstringになっている部分が混ざっていたので統一
  * PHPはintとstringの足し算でも型変換してよしなにやってくれるがint+intの方が間違いがないので統一する

## やらないこと

* なし

## できるようになること（ユーザ目線）

* なし

## できなくなること（ユーザ目線）

* なし

## 動作確認

* レスポンスの値の型を確認するテストを追加

## その他

* なし
